### PR TITLE
Implement demo rust unit testing

### DIFF
--- a/README.md
+++ b/README.md
@@ -9,3 +9,10 @@ This application is currently in early stages of development. Feel free to add i
 - [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens)
 - [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
 - [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode)
+
+## Commands
+
+- `pnpm run ui:dev` - runs UI server in browser
+- `pnpm run ui:build` - builds UI application
+- `pnpm run ui:format` - formats UI application
+- `pnpm run rust:test` - runs Rust unit tests

--- a/package.json
+++ b/package.json
@@ -8,7 +8,8 @@
     "dev": "vite",
     "build": "tsc && vite build",
     "preview": "vite preview",
-    "format": "prettier --write 'src/**/*.{ts,tsx}' && eslint src/*.{ts,tsx}"
+    "format": "prettier --write 'src/**/*.{ts,tsx}' && eslint src/*.{ts,tsx}",
+    "test-rust": "cd ./src-tauri; cargo test"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.6",

--- a/package.json
+++ b/package.json
@@ -5,11 +5,12 @@
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {
-    "dev": "vite",
-    "build": "tsc && vite build",
-    "preview": "vite preview",
-    "format": "prettier --write 'src/**/*.{ts,tsx}' && eslint src/*.{ts,tsx}",
-    "test-rust": "cd ./src-tauri; cargo test"
+    "ui:dev": "vite",
+    "ui:build": "tsc && vite build",
+    "ui:preview": "vite preview",
+    "ui:format": "prettier --write 'src/**/*.{ts,tsx}' && eslint src/*.{ts,tsx}",
+    "rust:dev": "tauri dev",
+    "rust:test": "cd ./src-tauri; cargo test"
   },
   "dependencies": {
     "@reduxjs/toolkit": "^1.8.6",

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,6 +3,28 @@
     windows_subsystem = "windows"
 )]
 
+// This function is included as a demo for unit testing
+// For more information, see the link below
+// https://doc.rust-lang.org/rust-by-example/testing/unit_testing.html
+pub fn add(a: i32, b: i32) -> i32 {
+    return a + b;
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_add() {
+        assert_eq!(add(1, 2), 3);
+    }
+
+    #[test]
+    fn test_add_negative() {
+        assert_eq!(add(1, -2), -1);
+    }
+}
+
 // Learn more about Tauri commands at https://tauri.app/v1/guides/features/command
 #[tauri::command]
 fn greet(name: &str) -> String {


### PR DESCRIPTION
This PR adds a demo rust unit test within the `src-tauri` directory that is intended to serve as a demo for adding unit testing into the rust backend code. This test will eventually be removed, as it is irrelevant to the functionality of the application. This testing can now be run with the `pnpm run test-rust` command in the parent directory of the client.

Closes #12 