### PR TITLE
Implemented Karger's Algorithm for finding global mincut

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -69,8 +69,8 @@ checksum = "216261ddc8289130e551ddcd5ce8a064710c0d064a4d2895c67151c92b5443f6"
 name = "app"
 version = "0.1.0"
 dependencies = [
- "defaultdict",
  "bytes",
+ "defaultdict",
  "petgraph",
  "prost",
  "prost-build",

--- a/src-tauri/src/GLOBALMINCUT.md
+++ b/src-tauri/src/GLOBALMINCUT.md
@@ -1,0 +1,48 @@
+**Procedure** Contract($G$)
+
+**repeat** until $G$ has 2 vertices.
+
+&emsp; **choose** an edge $(v, w)$ with probability proportional to the weight of $(v, w)$
+&emsp; **let** $G \leftarrow G / (v, w)$
+
+**return** $G$
+
+---
+
+**Procedure** to Contract Edge $(u, v)$
+
+**Let** $D(u) \leftarrow D(u) + D(v) - 2W(u, v)$
+
+**Let** $D(v) \leftarrow 0$
+
+**Let** $W(u, v) \leftarrow W(u, v) \leftarrow 0$
+
+For each vertex $w$ except $u$ and $v$
+
+&emsp; **Let** $W(u, w) \leftarrow W(u, w) + W(v, w)$
+
+&emsp; **Let** $W(w, u) \leftarrow W(w, u) + W(w, v)$
+
+&emsp; **Let** $W(v, w) \leftarrow W(w, v) \leftarrow 0$
+
+---
+
+Recursive-Contract($G,n$)
+
+**input** A graph $G$ of size $n$.
+
+**if** $G$ has fewer than 6 vertices
+
+**then**
+
+&emsp; $G' \leftarrow Contract(G,2)$
+
+&emsp; **return** the weight of cut ($A = s(a), B=s(b)$) in $G'$
+
+**else repeat twice**
+
+&emsp; $G' \leftarrow Contract(G, \lceil n/ \sqrt 2 + 1 \rceil) $
+
+&emsp; $G' \leftarrow Recursive-Contract(G', \lceil n/ \sqrt 2 + 1 \rceil) $
+
+&emsp; **return** the smaller of the two resulting values.

--- a/src-tauri/src/globalmincut.rs
+++ b/src-tauri/src/globalmincut.rs
@@ -52,67 +52,6 @@ pub fn random_select(G: &Graph) -> Edge {
     return edges[i].clone();
 }
 
-/*
-pub fn contract_edge(G: &mut Graph, edge: &Edge) {
-    {
-        let u_idx = edge.u.clone();
-        let v_idx = edge.v.clone();
-
-        let node_u = G.g.node_weight(u_idx).unwrap();
-        let node_v = G.g.node_weight(v_idx).unwrap();
-
-        let u_weighted_degree = node_u.optimal_weighted_degree;
-        let v_weighted_degree = node_v.optimal_weighted_degree;
-
-        let edge_weight = edge.weight;
-
-        let new_value = u_weighted_degree + v_weighted_degree - 2.0 * edge_weight;
-
-        G.change_node_opt_weight(u_idx, new_value);
-        G.change_node_opt_weight(v_idx, 0 as f64);
-    }
-
-    let u_idx = edge.u.clone();
-    let v_idx = edge.v.clone();
-    let node_u = G.get_node(u_idx.clone());
-    let node_v = G.get_node(v_idx.clone());
-
-    println!("Edge: {:?} {:?}", node_u, node_v);
-
-    G.update_edge(node_u.name.clone(), node_v.name.clone(), 0 as f64);
-    G.update_edge(node_v.name.clone(), node_u.name.clone(), 0 as f64);
-
-    for node in G.get_nodes() {
-        if node != node_u.clone() && node != node_v.clone() {
-            // edge = (u, v)
-            let weight = G.get_edge_weight(node_u.name.clone(), node.name.clone())
-                + G.get_edge_weight(node_v.name.clone(), node.name.clone());
-            G.update_edge(node_u.name.clone(), node.name.clone(), weight);
-            let weight = G.get_edge_weight(node.name.clone(), node_u.name.clone())
-                + G.get_edge_weight(node.name.clone(), node_v.name.clone());
-            G.update_edge(node.name.clone(), node_u.name.clone(), weight);
-            G.update_edge(node_v.name.clone(), node.name.clone(), 0 as f64);
-            G.update_edge(node.name.clone(), node_v.name.clone(), 0 as f64);
-        }
-    }
-}
-
-pub fn contract(G: &Graph, k: usize) -> Graph {
-    let mut g_prime = G.clone();
-    let n = g_prime.get_order();
-    while g_prime.get_order() > k {
-        println!("Order: {}", g_prime.get_order());
-        let e = random_select(&g_prime);
-        contract_edge(&mut g_prime, &e);
-        let node_u = g_prime.g.node_weight(e.u).unwrap();
-        let node_v = g_prime.g.node_weight(e.v).unwrap();
-        g_prime.remove_edge(node_u.name.clone(), node_v.name.clone());
-    }
-    let edges = g_prime.get_edges();
-    g_prime
-}
-*/
-
 pub fn contract(G: &Graph, k: usize) -> Graph {
     let mut G = G.clone();
 

--- a/src-tauri/src/globalmincut.rs
+++ b/src-tauri/src/globalmincut.rs
@@ -1,0 +1,219 @@
+#![allow(dead_code)]
+
+use crate::graph_p::Edge;
+use crate::graph_p::Graph;
+
+pub fn bisect_left<T: PartialOrd>(a: &[T], x: T) -> usize {
+    let mut lo = 0;
+    let mut hi = a.len();
+
+    if lo < 0 {
+        panic!("lo must be non-negative");
+    }
+    if hi == 0 {
+        hi = a.len();
+    }
+    while lo < hi {
+        let mid = (lo + hi) / 2;
+        if a[mid] < x {
+            lo = mid + 1;
+        } else {
+            hi = mid;
+        }
+    }
+    lo
+}
+
+pub fn random_select(G: &Graph) -> Edge {
+    // Calculate the cumulative edge weights
+    let cumulative_edge_weights = G.get_cumulative_edge_weights();
+    println!("cumulative_edge_weights: {:?}", cumulative_edge_weights);
+    let total_weight = cumulative_edge_weights[cumulative_edge_weights.len() - 1];
+
+    let r = rand::random::<f64>() * (total_weight as f64);
+    let i = bisect_left(&cumulative_edge_weights, r);
+    let edges = G.get_edges();
+    return edges[i].clone();
+}
+
+/*
+pub fn contract_edge(G: &mut Graph, edge: &Edge) {
+    {
+        let u_idx = edge.u.clone();
+        let v_idx = edge.v.clone();
+
+        let node_u = G.g.node_weight(u_idx).unwrap();
+        let node_v = G.g.node_weight(v_idx).unwrap();
+
+        let u_weighted_degree = node_u.optimal_weighted_degree;
+        let v_weighted_degree = node_v.optimal_weighted_degree;
+
+        let edge_weight = edge.weight;
+
+        let new_value = u_weighted_degree + v_weighted_degree - 2.0 * edge_weight;
+
+        G.change_node_opt_weight(u_idx, new_value);
+        G.change_node_opt_weight(v_idx, 0 as f64);
+    }
+
+    let u_idx = edge.u.clone();
+    let v_idx = edge.v.clone();
+    let node_u = G.get_node(u_idx.clone());
+    let node_v = G.get_node(v_idx.clone());
+
+    println!("Edge: {:?} {:?}", node_u, node_v);
+
+    G.update_edge(node_u.name.clone(), node_v.name.clone(), 0 as f64);
+    G.update_edge(node_v.name.clone(), node_u.name.clone(), 0 as f64);
+
+    for node in G.get_nodes() {
+        if node != node_u.clone() && node != node_v.clone() {
+            // edge = (u, v)
+            let weight = G.get_edge_weight(node_u.name.clone(), node.name.clone())
+                + G.get_edge_weight(node_v.name.clone(), node.name.clone());
+            G.update_edge(node_u.name.clone(), node.name.clone(), weight);
+            let weight = G.get_edge_weight(node.name.clone(), node_u.name.clone())
+                + G.get_edge_weight(node.name.clone(), node_v.name.clone());
+            G.update_edge(node.name.clone(), node_u.name.clone(), weight);
+            G.update_edge(node_v.name.clone(), node.name.clone(), 0 as f64);
+            G.update_edge(node.name.clone(), node_v.name.clone(), 0 as f64);
+        }
+    }
+}
+
+pub fn contract(G: &Graph, k: usize) -> Graph {
+    let mut g_prime = G.clone();
+    let n = g_prime.get_order();
+    while g_prime.get_order() > k {
+        println!("Order: {}", g_prime.get_order());
+        let e = random_select(&g_prime);
+        contract_edge(&mut g_prime, &e);
+        let node_u = g_prime.g.node_weight(e.u).unwrap();
+        let node_v = g_prime.g.node_weight(e.v).unwrap();
+        g_prime.remove_edge(node_u.name.clone(), node_v.name.clone());
+    }
+    let edges = g_prime.get_edges();
+    g_prime
+}
+*/
+
+pub fn contract_2(G: &Graph, k: usize) -> Graph {
+    let mut G = G.clone();
+
+    while G.get_order() > k {
+        let e = random_select(&G);
+
+        let start_idx = e.u.clone();
+        let finish_idx = e.v.clone();
+
+        let start = G.get_node(start_idx.clone());
+        let finish = G.get_node(finish_idx.clone());
+
+        println!(
+            "Random Edge: {:?} {:?}",
+            start.name.clone(),
+            finish.name.clone()
+        );
+
+        for node in G.get_neighbors(finish.name.clone()) {
+            if !node.name.eq(&start.name) {
+                let weight =
+                    G.get_edge_weight(finish.name.clone(), node.name.clone(), None, Some(true));
+                G.add_edge(start.name.clone(), node.name.clone(), weight);
+            }
+        }
+
+        G.remove_node(finish_idx.clone());
+    }
+
+    // print the edges
+    for edge in G.get_edges() {
+        let start = G.get_node(edge.u.clone());
+        let finish = G.get_node(edge.v.clone());
+        println!("Edge: {:?} {:?}", start.name.clone(), finish.name.clone());
+    }
+    return G.clone();
+}
+
+pub fn karger_stein_gmincut(G: &Graph, n: i32) -> f64 {
+    if n <= 6 {
+        let g_prime = contract_2(G, 2);
+        let mut cut_sum = 0.0;
+        for edge in g_prime.get_edges() {
+            cut_sum += edge.weight;
+        }
+        return cut_sum;
+    } else {
+        let n = (n as f64 / 2.0f64.sqrt()) as i32 + 1;
+        let g_prime_1 = contract_2(G, n as usize);
+        let g_prime_1_min_cut = karger_stein_gmincut(&g_prime_1, n);
+
+        let g_prime_2 = contract_2(G, n as usize);
+        let g_prime_2_min_cut = karger_stein_gmincut(&g_prime_2, n);
+
+        if g_prime_1_min_cut > g_prime_2_min_cut {
+            return g_prime_2_min_cut;
+        } else {
+            return g_prime_1_min_cut;
+        }
+    }
+}
+
+// Create a unit test for the Graph struct
+#[cfg(test)]
+mod tests {
+    use std::env;
+
+    use super::*;
+
+    #[test]
+    fn run_globalmincut() {
+        env::set_var("RUST_BACKTRACE", "1");
+        // Create a graph
+        let mut G = Graph::new();
+
+        // Add nodes
+        let u: String = "u".to_string();
+        let v: String = "v".to_string();
+        let w: String = "w".to_string();
+        let x: String = "x".to_string();
+        let y: String = "y".to_string();
+
+        G.add_node(u.clone());
+        G.add_node(v.clone());
+        G.add_node(w.clone());
+        G.add_node(x.clone());
+        G.add_node(y.clone());
+
+        // Add edges
+        G.add_edge(u.clone(), v.clone(), 1.0);
+        G.add_edge(u.clone(), w.clone(), 1.0);
+        G.add_edge(u.clone(), x.clone(), 1.0);
+        G.add_edge(w.clone(), x.clone(), 1.0);
+        G.add_edge(v.clone(), y.clone(), 1.0);
+        G.add_edge(x.clone(), y.clone(), 1.0);
+
+        for edge in G.get_edges() {
+            let node_u = G.g.node_weight(edge.u.clone()).unwrap();
+            let node_v = G.g.node_weight(edge.v.clone()).unwrap();
+            println!(
+                "Edge: (Name: {} - Degree Weight: {}) <-> (Name: {} - Degree Weight: {}) with weight {}",
+                node_u.name, node_u.optimal_weighted_degree, node_v.name, node_v.optimal_weighted_degree, edge.weight
+            );
+        }
+        // Run the algorithm 50 times and save the times where mincut is 2 to a variable
+        let mut mincut_2 = 0;
+        for _ in 0..10000 {
+            let order = G.get_order();
+            let mincut = karger_stein_gmincut(&G.clone(), order as i32);
+            if mincut == 2.0 {
+                mincut_2 += 1;
+            }
+        }
+
+        println!("{} out of 10000", mincut_2);
+        //let order = G.get_order();
+        //let mincut = karger_stein_gmincut(&G, order as i32);
+        //println!("mincut: {}", mincut);
+    }
+}

--- a/src-tauri/src/globalmincut.rs
+++ b/src-tauri/src/globalmincut.rs
@@ -3,6 +3,18 @@
 use crate::graph_p::Edge;
 use crate::graph_p::Graph;
 
+/// Locate the insertion point for x in a to maintain sorted order.
+/// If x is already present in a, the insertion point will be before
+/// (to the left of) any existing entries.
+///
+/// The returned insertion point i partitions the array a into two
+/// halves so that all(val < x for val in a[lo : i]) for the left
+/// side and all(val >= x for val in a[i : hi]) for the right side.
+///
+/// * Arguments
+///
+/// * `a` - The sorted slice to search.
+/// * `x` - The value to search for.
 pub fn bisect_left<T: PartialOrd>(a: &[T], x: T) -> usize {
     let mut lo = 0;
     let mut hi = a.len();
@@ -24,10 +36,14 @@ pub fn bisect_left<T: PartialOrd>(a: &[T], x: T) -> usize {
     lo
 }
 
+/// Returns the edge picked randomly proportional to the weight of the edge
+///
+/// * Arguments
+///
+/// * `G` - The graph to pick the edge from
 pub fn random_select(G: &Graph) -> Edge {
     // Calculate the cumulative edge weights
     let cumulative_edge_weights = G.get_cumulative_edge_weights();
-    println!("cumulative_edge_weights: {:?}", cumulative_edge_weights);
     let total_weight = cumulative_edge_weights[cumulative_edge_weights.len() - 1];
 
     let r = rand::random::<f64>() * (total_weight as f64);
@@ -97,7 +113,7 @@ pub fn contract(G: &Graph, k: usize) -> Graph {
 }
 */
 
-pub fn contract_2(G: &Graph, k: usize) -> Graph {
+pub fn contract(G: &Graph, k: usize) -> Graph {
     let mut G = G.clone();
 
     while G.get_order() > k {
@@ -109,12 +125,6 @@ pub fn contract_2(G: &Graph, k: usize) -> Graph {
         let start = G.get_node(start_idx.clone());
         let finish = G.get_node(finish_idx.clone());
 
-        println!(
-            "Random Edge: {:?} {:?}",
-            start.name.clone(),
-            finish.name.clone()
-        );
-
         for node in G.get_neighbors(finish.name.clone()) {
             if !node.name.eq(&start.name) {
                 let weight =
@@ -122,22 +132,14 @@ pub fn contract_2(G: &Graph, k: usize) -> Graph {
                 G.add_edge(start.name.clone(), node.name.clone(), weight);
             }
         }
-
         G.remove_node(finish_idx.clone());
-    }
-
-    // print the edges
-    for edge in G.get_edges() {
-        let start = G.get_node(edge.u.clone());
-        let finish = G.get_node(edge.v.clone());
-        println!("Edge: {:?} {:?}", start.name.clone(), finish.name.clone());
     }
     return G.clone();
 }
 
 pub fn karger_stein_gmincut(G: &Graph, n: i32) -> f64 {
     if n <= 6 {
-        let g_prime = contract_2(G, 2);
+        let g_prime = contract(G, 2);
         let mut cut_sum = 0.0;
         for edge in g_prime.get_edges() {
             cut_sum += edge.weight;
@@ -145,10 +147,10 @@ pub fn karger_stein_gmincut(G: &Graph, n: i32) -> f64 {
         return cut_sum;
     } else {
         let n = (n as f64 / 2.0f64.sqrt()) as i32 + 1;
-        let g_prime_1 = contract_2(G, n as usize);
+        let g_prime_1 = contract(G, n as usize);
         let g_prime_1_min_cut = karger_stein_gmincut(&g_prime_1, n);
 
-        let g_prime_2 = contract_2(G, n as usize);
+        let g_prime_2 = contract(G, n as usize);
         let g_prime_2_min_cut = karger_stein_gmincut(&g_prime_2, n);
 
         if g_prime_1_min_cut > g_prime_2_min_cut {
@@ -162,13 +164,10 @@ pub fn karger_stein_gmincut(G: &Graph, n: i32) -> f64 {
 // Create a unit test for the Graph struct
 #[cfg(test)]
 mod tests {
-    use std::env;
-
     use super::*;
 
     #[test]
     fn run_globalmincut() {
-        env::set_var("RUST_BACKTRACE", "1");
         // Create a graph
         let mut G = Graph::new();
 
@@ -178,12 +177,18 @@ mod tests {
         let w: String = "w".to_string();
         let x: String = "x".to_string();
         let y: String = "y".to_string();
+        let z: String = "z".to_string();
+        let a: String = "a".to_string();
+        let b: String = "b".to_string();
 
         G.add_node(u.clone());
         G.add_node(v.clone());
         G.add_node(w.clone());
         G.add_node(x.clone());
         G.add_node(y.clone());
+        G.add_node(z.clone());
+        G.add_node(a.clone());
+        G.add_node(b.clone());
 
         // Add edges
         G.add_edge(u.clone(), v.clone(), 1.0);
@@ -192,6 +197,9 @@ mod tests {
         G.add_edge(w.clone(), x.clone(), 1.0);
         G.add_edge(v.clone(), y.clone(), 1.0);
         G.add_edge(x.clone(), y.clone(), 1.0);
+        G.add_edge(w.clone(), z.clone(), 1.0);
+        G.add_edge(x.clone(), a.clone(), 1.0);
+        G.add_edge(y.clone(), b.clone(), 1.0);
 
         for edge in G.get_edges() {
             let node_u = G.g.node_weight(edge.u.clone()).unwrap();
@@ -201,19 +209,16 @@ mod tests {
                 node_u.name, node_u.optimal_weighted_degree, node_v.name, node_v.optimal_weighted_degree, edge.weight
             );
         }
-        // Run the algorithm 50 times and save the times where mincut is 2 to a variable
+
         let mut mincut_2 = 0;
         for _ in 0..10000 {
             let order = G.get_order();
             let mincut = karger_stein_gmincut(&G.clone(), order as i32);
-            if mincut == 2.0 {
+            if mincut == 1.0 {
                 mincut_2 += 1;
             }
         }
 
         println!("{} out of 10000", mincut_2);
-        //let order = G.get_order();
-        //let mincut = karger_stein_gmincut(&G, order as i32);
-        //println!("mincut: {}", mincut);
     }
 }

--- a/src-tauri/src/graph_p.rs
+++ b/src-tauri/src/graph_p.rs
@@ -1,4 +1,7 @@
+#![allow(dead_code)]
+
 use petgraph::prelude::*;
+use petgraph::stable_graph::StableUnGraph;
 use std::collections::HashMap;
 
 #[derive(Debug)]
@@ -86,23 +89,29 @@ impl PartialEq for Edge {
 }
 
 pub struct Graph {
-    pub g: StableGraph<Node, Edge>,
+    pub g: StableGraph<Node, Edge, Undirected>,
     pub node_idx_map: HashMap<String, petgraph::graph::NodeIndex>,
     pub edge_idx_map: HashMap<
         (petgraph::graph::NodeIndex, petgraph::graph::NodeIndex),
-        petgraph::graph::EdgeIndex,
+        Vec<petgraph::graph::EdgeIndex>,
     >,
 }
 
 impl Graph {
+    /// Creates a new graph and returns it.
     pub fn new() -> Graph {
         Graph {
-            g: StableGraph::new(),
+            g: StableUnGraph::<Node, Edge>::default(), // StableGraph::new(),
             node_idx_map: HashMap::new(),
             edge_idx_map: HashMap::new(),
         }
     }
 
+    /// Add a node to the graph. Returns the node index.
+    ///
+    /// # Arguments
+    ///
+    /// * `name` - String identifier of the node.
     pub fn add_node(&mut self, name: String) -> petgraph::graph::NodeIndex {
         let node = Node::new(name.clone());
         let node_idx = self.g.add_node(node.clone());
@@ -110,23 +119,43 @@ impl Graph {
         node_idx
     }
 
+    /// Removes node from the graph (and all edges connected to it). Does not return anything.
+    ///
+    /// # Arguments
+    ///
+    /// * `node_idx` - Node index of the node to be removed.
     pub fn remove_node(&mut self, node: petgraph::graph::NodeIndex) {
-        //let node_idx = self.node_idx_map.get(&name).unwrap();
         let node_u = self.g.node_weight(node).unwrap().clone();
 
         for neighbor_node in self.get_neighbors_idx(node_u.name.clone()) {
             let node_v = self.g.node_weight(neighbor_node.clone()).unwrap();
-            self.remove_edge(node_u.name.clone(), node_v.name.clone());
+            self.remove_edge(node_u.name.clone(), node_v.name.clone(), None, Some(false));
         }
 
         self.g.remove_node(node.clone());
     }
 
-    pub fn change_node_opt_weight(&mut self, idx: petgraph::graph::NodeIndex, weight: f64) {
+    /// Updates the weight of the node. Does not return anything.
+    ///
+    /// # Arguments
+    ///
+    /// * `idx` - Index of the node we want to update, represented as NodeIndex
+    /// * `new_weight` - New weight of the node
+    pub fn change_node_opt_weight(&mut self, idx: petgraph::graph::NodeIndex, new_weight: f64) {
         let mut node = self.g.node_weight_mut(idx).unwrap();
-        node.optimal_weighted_degree += weight;
+        node.optimal_weighted_degree = new_weight * 2.0;
     }
 
+    /// Adds the edge to the graph and insert the edge index into the edge_idx_map
+    /// (where the key is the tuple of the node indices and the value is the list
+    /// of edges). We maintain a list because we allow parallel edges to exist.
+    /// Does not return anything.
+    ///
+    /// # Arguments
+    ///
+    /// * `u` - String identifier of the first node
+    /// * `v` - String identifier of the second node
+    /// * `weight` - Float weight of the edge
     pub fn add_edge(&mut self, u: String, v: String, weight: f64) {
         if !self.node_idx_map.contains_key(&u) {
             let error_message = format!("Node {} does not exist", u);
@@ -137,34 +166,48 @@ impl Graph {
             return print_error_and_return(&error_message);
         }
 
-        let u_idx = self.node_idx_map.get(&u).unwrap();
-        let v_idx = self.node_idx_map.get(&v).unwrap();
+        let u_idx = self.node_idx_map.get(&u).unwrap().clone();
+        let v_idx = self.node_idx_map.get(&v).unwrap().clone();
 
-        // Check if edge already exists
-        if self.g.contains_edge(u_idx.clone(), v_idx.clone()) {
-            let error_message = format!("Edge ({}, {}) already exists", u.clone(), v.clone());
-            return print_error_and_return(&error_message);
-        }
+        let edge = Edge::new(u_idx.clone(), v_idx.clone(), weight);
 
-        let edge_1 = Edge::new(u_idx.clone(), v_idx.clone(), weight);
-        let edge_2 = Edge::new(v_idx.clone(), u_idx.clone(), weight);
+        let edge_idx = self.g.add_edge(u_idx.clone(), v_idx.clone(), edge);
 
-        let edge_idx_1 = self.g.add_edge(u_idx.clone(), v_idx.clone(), edge_1);
-        let edge_idx_2 = self.g.add_edge(v_idx.clone(), u_idx.clone(), edge_2);
+        // Insert new edge into edge_idx_map which maps (u, v) to a list of edge indices
+        let edge_idx_list = self
+            .edge_idx_map
+            .entry((u_idx.clone(), v_idx.clone()))
+            .or_insert(Vec::new());
 
-        let u_idx_clone = u_idx.clone();
-        let v_idx_clone = v_idx.clone();
+        edge_idx_list.push(edge_idx);
 
-        self.edge_idx_map
-            .insert((u_idx.clone(), v_idx.clone()), edge_idx_1.clone());
-        self.edge_idx_map
-            .insert((v_idx.clone(), u_idx.clone()), edge_idx_2.clone());
+        // Insert new edge into edge_idx_map which maps (v, u) to a list of edge indices
+        let edge_idx_list = self
+            .edge_idx_map
+            .entry((v_idx.clone(), u_idx.clone()))
+            .or_insert(Vec::new());
 
-        self.change_node_opt_weight(u_idx_clone, weight);
-        self.change_node_opt_weight(v_idx_clone, weight);
+        edge_idx_list.push(edge_idx);
+
+        self.change_node_opt_weight(u_idx.clone(), weight);
+        self.change_node_opt_weight(v_idx.clone(), weight);
     }
 
-    pub fn update_edge(&mut self, u: String, v: String, weight: f64) {
+    /// Updates the weight of the edge. Does not return anything.
+    ///
+    /// # Arguments
+    ///
+    /// * `u` - String identifier of the first node
+    /// * `v` - String identifier of the second node
+    /// * `weight` - Float weight of the edge
+    /// * `parallel_edge_idx` - Optional usize index of the parallel edge we want to update.
+    pub fn update_edge(
+        &mut self,
+        u: String,
+        v: String,
+        weight: f64,
+        parallel_edge_idx: Option<usize>,
+    ) {
         if !self.node_idx_map.contains_key(&u) {
             let error_message = format!("Node {} does not exist", u);
             return print_error_and_return(&error_message);
@@ -187,33 +230,47 @@ impl Graph {
             .edge_idx_map
             .get(&(u_idx.clone(), v_idx.clone()))
             .unwrap();
-        let old_weight = self.g.edge_weight(edge_idx.clone()).unwrap().weight;
+        let old_weight = self
+            .g
+            .edge_weight(edge_idx.clone()[parallel_edge_idx.unwrap_or(0)])
+            .unwrap()
+            .weight;
 
         let edge_1 = Edge::new(u_idx.clone(), v_idx.clone(), weight);
-        let edge_2 = Edge::new(v_idx.clone(), u_idx.clone(), weight);
 
         let edge_idx_1 = self.g.update_edge(u_idx.clone(), v_idx.clone(), edge_1);
-        let edge_idx_2 = self.g.update_edge(v_idx.clone(), u_idx.clone(), edge_2);
+        //let edge_idx_2 = self.g.update_edge(v_idx.clone(), u_idx.clone(), edge_2);
 
         let u_idx_clone = u_idx.clone();
         let v_idx_clone = v_idx.clone();
 
         // Update edge_idx_map to reflect the new edge index
-        self.edge_idx_map
-            .entry((u_idx.clone(), v_idx.clone()))
-            .and_modify(|e| *e = edge_idx_1)
-            .or_insert(edge_idx_1);
+        let edge_idx_list = self
+            .edge_idx_map
+            .entry((u_idx_clone, v_idx_clone))
+            .or_insert(Vec::new());
 
-        self.edge_idx_map
-            .entry((v_idx.clone(), u_idx.clone()))
-            .and_modify(|e| *e = edge_idx_2)
-            .or_insert(edge_idx_2);
+        edge_idx_list[parallel_edge_idx.unwrap_or(0)] = edge_idx_1;
+
+        // Update edge_idx_map to reflect the new edge index
+        let edge_idx_list = self
+            .edge_idx_map
+            .entry((v_idx_clone, u_idx_clone))
+            .or_insert(Vec::new());
+
+        edge_idx_list[parallel_edge_idx.unwrap_or(0)] = edge_idx_1;
 
         self.change_node_opt_weight(u_idx_clone, weight - old_weight);
         self.change_node_opt_weight(v_idx_clone, weight - old_weight);
     }
 
-    pub fn get_edge_weight(&self, u: String, v: String) -> f64 {
+    pub fn get_edge_weight(
+        &self,
+        u: String,
+        v: String,
+        parallel_edge_idx: Option<usize>,
+        get_all_parallel: Option<bool>,
+    ) -> f64 {
         if !self.node_idx_map.contains_key(&u) {
             let error_message = format!("Node {} does not exist", u);
             println!("{}", error_message);
@@ -233,16 +290,42 @@ impl Graph {
             return 0.0;
         }
 
-        let edge_idx = self
+        let edge_idx_list = self
             .edge_idx_map
             .get(&(u_idx.clone(), v_idx.clone()))
             .unwrap();
-        let weight = self.g.edge_weight(edge_idx.clone()).unwrap().weight;
+
+        let mut weight = 0.0;
+        if get_all_parallel.unwrap_or(false) {
+            weight = self
+                .g
+                .edge_weight(edge_idx_list.clone()[parallel_edge_idx.unwrap_or(0)])
+                .unwrap()
+                .weight;
+        } else {
+            for edge_idx in edge_idx_list {
+                weight += self.g.edge_weight(edge_idx.clone()).unwrap().weight;
+            }
+        }
 
         weight
     }
 
-    pub fn remove_edge(&mut self, u: String, v: String) {
+    /// Removes an edge from the graph. Does not return anything.
+    ///
+    /// # Arguments
+    ///
+    /// * `u` - String identifier of the first node
+    /// * `v` - String identifier of the second node
+    /// * `parallel_edge_idx` - Optional usize index of the parallel edge we want to remove.
+    /// * `remove_all_parallel` - Optional bool flag to remove all parallel edges.
+    pub fn remove_edge(
+        &mut self,
+        u: String,
+        v: String,
+        parallel_edge_idx: Option<usize>,
+        remove_all_parallel: Option<bool>,
+    ) {
         if !self.node_idx_map.contains_key(&u) {
             let error_message = format!("Node {} does not exist", u);
             return print_error_and_return(&error_message);
@@ -252,8 +335,8 @@ impl Graph {
             return print_error_and_return(&error_message);
         }
 
-        let u_idx = self.node_idx_map.get(&u).unwrap();
-        let v_idx = self.node_idx_map.get(&v).unwrap();
+        let u_idx = self.node_idx_map.get(&u).unwrap().clone();
+        let v_idx = self.node_idx_map.get(&v).unwrap().clone();
 
         // Check if edge does not exist
         if !self.g.contains_edge(u_idx.clone(), v_idx.clone()) {
@@ -261,39 +344,67 @@ impl Graph {
             return print_error_and_return("Edge does not exist");
         }
 
-        let edge_idx_1 = self
+        let edge_idx_list = self
             .edge_idx_map
             .get(&(u_idx.clone(), v_idx.clone()))
-            .unwrap();
+            .unwrap()
+            .clone();
 
-        let edge_idx_2 = self
-            .edge_idx_map
-            .get(&(v_idx.clone(), u_idx.clone()))
-            .unwrap();
+        // If remove_all_parallel is false, then remove the single edge in the list whose
+        // index is parallel_edge_idx (default 0).
+        if !remove_all_parallel.unwrap_or(false) {
+            let weight = self
+                .g
+                .edge_weight(edge_idx_list.clone()[parallel_edge_idx.unwrap_or(0)])
+                .unwrap()
+                .weight;
 
-        let weight = self.g.edge_weight(edge_idx_1.clone()).unwrap().weight;
+            self.g
+                .remove_edge(edge_idx_list.clone()[parallel_edge_idx.unwrap_or(0)]);
 
-        self.g.remove_edge(edge_idx_1.clone());
-        self.g.remove_edge(edge_idx_2.clone());
+            let edge_idx_list_mut = self
+                .edge_idx_map
+                .entry((v_idx.clone(), u_idx.clone()))
+                .or_insert(Vec::new());
 
-        let u_idx_clone = u_idx.clone();
-        let v_idx_clone = v_idx.clone();
+            edge_idx_list_mut.swap_remove(parallel_edge_idx.unwrap_or(0));
 
-        self.edge_idx_map.remove(&(u_idx.clone(), v_idx.clone()));
-        self.edge_idx_map.remove(&(v_idx.clone(), u_idx.clone()));
+            let edge_idx_list_mut = self
+                .edge_idx_map
+                .entry((u_idx.clone(), v_idx.clone()))
+                .or_insert(Vec::new());
 
-        self.change_node_opt_weight(u_idx_clone, -weight);
-        self.change_node_opt_weight(v_idx_clone, -weight);
+            edge_idx_list_mut.swap_remove(parallel_edge_idx.unwrap_or(0));
+
+            self.change_node_opt_weight(u_idx.clone(), -weight);
+            self.change_node_opt_weight(v_idx.clone(), -weight);
+        } else {
+            // If remove_all_parallel is true, then remove all edges in the list.
+            for edge_idx in edge_idx_list.clone() {
+                let weight = self.g.edge_weight(edge_idx.clone()).unwrap().weight;
+
+                self.g.remove_edge(edge_idx.clone());
+
+                self.change_node_opt_weight(u_idx.clone(), -weight);
+                self.change_node_opt_weight(v_idx.clone(), -weight);
+            }
+
+            self.edge_idx_map.remove(&(u_idx.clone(), v_idx.clone()));
+            self.edge_idx_map.remove(&(v_idx.clone(), u_idx.clone()));
+        }
     }
 
+    /// Returns the number of nodes in the graph.
     pub fn get_order(&self) -> usize {
         self.g.node_count()
     }
 
+    /// Returns the number of edges in the graph.
     pub fn get_size(&self) -> usize {
         self.g.edge_count()
     }
 
+    /// Clones the graph and returns it.
     pub fn clone(&self) -> Graph {
         Graph {
             g: self.g.clone(),
@@ -302,7 +413,7 @@ impl Graph {
         }
     }
 
-    // Currently immutable
+    /// Returns all the nodes in the graph.
     pub fn get_nodes(&self) -> Vec<Node> {
         let mut nodes = Vec::new();
         for node in self.g.node_weights() {
@@ -311,16 +422,25 @@ impl Graph {
         nodes
     }
 
-    // Get node given idx
+    /// Returns the node associated with the given node index.
+    ///
+    /// # Arguments
+    ///
+    /// * `node_idx` - NodeIndex of the node we want to get.
     pub fn get_node(&self, idx: petgraph::graph::NodeIndex) -> Node {
         self.g.node_weight(idx).unwrap().clone()
     }
 
+    /// Returns the node index associated with the given node identifier.
+    ///
+    /// # Arguments
+    ///
+    /// * `node_id` - String identifier of the node we want to get.
     pub fn get_node_idx(&self, node: String) -> petgraph::graph::NodeIndex {
         self.node_idx_map.get(&node).unwrap().clone()
     }
 
-    // Currently immutable
+    /// Returns a list of all the edges in the graph.
     pub fn get_edges(&self) -> Vec<Edge> {
         let mut edges = Vec::new();
         for edge in self.g.edge_weights() {
@@ -329,26 +449,41 @@ impl Graph {
         edges
     }
 
+    /// Returns the nodes connected to the given node.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - String identifier of the node we want to get the neighbors of.
     pub fn get_neighbors(&self, node: String) -> Vec<Node> {
         let node_weight = self.node_idx_map.get(&node).unwrap();
         let mut neighbors = Vec::new();
-        for neighbor in self.g.neighbors(node_weight.clone()) {
+        for neighbor in self.g.neighbors_undirected(node_weight.clone()) {
             neighbors.push(self.g.node_weight(neighbor).unwrap().clone());
         }
 
         neighbors
     }
 
+    /// Returns the indices of the nodes connected to the given node.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - String identifier of the node we want to get the neighbors of.
     pub fn get_neighbors_idx(&self, node: String) -> Vec<petgraph::graph::NodeIndex> {
         let node_weight = self.node_idx_map.get(&node).unwrap();
         let mut neighbors = Vec::new();
-        for neighbor in self.g.neighbors(node_weight.clone()) {
-            neighbors.push(neighbor);
+        for neighbor in self.g.neighbors_undirected(node_weight.clone()) {
+            neighbors.push(neighbor.clone());
         }
 
         neighbors
     }
 
+    /// Returns the number of edges connected to the given node.
+    ///
+    /// # Arguments
+    ///
+    /// * `node` - String identifier of the node we want to get the degree of.
     pub fn degree_of(&self, node: String) -> usize {
         if !self.node_idx_map.contains_key(&node) {
             let error_message = format!("Node {} does not exist", node);
@@ -357,14 +492,15 @@ impl Graph {
         }
 
         let node_idx = self.node_idx_map.get(&node).unwrap();
-        self.g.neighbors(node_idx.clone()).count()
+        self.g.neighbors_undirected(node_idx.clone()).count()
     }
 
+    /// Returns a list of cumulative edge weights.
     pub fn get_cumulative_edge_weights(&self) -> Vec<f64> {
         let mut cumulative_edge_weights = Vec::new();
         let mut total_weight = 0.0;
         for edge in self.g.edge_weights() {
-            total_weight += edge.weight;
+            total_weight += edge.weight * 2.0;
             cumulative_edge_weights.push(total_weight);
         }
         cumulative_edge_weights
@@ -399,13 +535,29 @@ mod tests {
         assert_eq!(G.get_order(), 3);
 
         G.add_edge(u.clone(), v.clone(), 1 as f64);
-        // This should return an error "Edge already exists"
-        G.add_edge(u.clone(), v.clone(), 2 as f64);
         G.add_edge(u.clone(), w.clone(), 1 as f64);
         G.add_edge(v.clone(), w.clone(), 35 as f64);
-        // Since this is an undirected graph, each edge is added twice
-        assert_eq!(G.get_size(), 6);
 
+        assert_eq!(G.get_size(), 3);
+
+        /*
+        for edge in G.get_edges() {
+            let node_u = G.g.node_weight(edge.u.clone()).unwrap();
+            let node_v = G.g.node_weight(edge.v.clone()).unwrap();
+            println!(
+                "Edge: (Name: {} - Degree Weight: {}) <-> (Name: {} - Degree Weight: {}) with weight {}",
+                node_u.name, node_u.optimal_weighted_degree, node_v.name, node_v.optimal_weighted_degree, edge.weight
+            );
+        }
+        println!("\n");
+        */
+
+        G.update_edge(u.clone(), v.clone(), 11 as f64, None);
+        G.remove_edge(u.clone(), w.clone(), None, Some(true));
+
+        assert_eq!(G.get_size(), 2);
+
+        /*
         for edge in G.get_edges() {
             let node_u = G.g.node_weight(edge.u.clone()).unwrap();
             let node_v = G.g.node_weight(edge.v.clone()).unwrap();
@@ -416,19 +568,6 @@ mod tests {
         }
         println!("\n");
 
-        G.update_edge(u.clone(), v.clone(), 11 as f64);
-
-        G.remove_edge(u.clone(), w.clone());
-        assert_eq!(G.get_size(), 4);
-        for edge in G.get_edges() {
-            let node_u = G.g.node_weight(edge.u.clone()).unwrap();
-            let node_v = G.g.node_weight(edge.v.clone()).unwrap();
-            println!(
-                "Edge: (Name: {} - Degree Weight: {}) <-> (Name: {} - Degree Weight: {}) with weight {}",
-                node_u.name, node_u.optimal_weighted_degree, node_v.name, node_v.optimal_weighted_degree, edge.weight
-            );
-        }
-        println!("\n");
 
         // Print the edges and nodes in the graph
         println!("Edges: {:?}", G.get_edges());
@@ -437,6 +576,7 @@ mod tests {
         println!("Cumulative edge weights: {:?}", cum_sum);
 
         println!("Degree of {}: {}", u, G.degree_of(u.clone()));
+        println!("Neighborhood of {}: {:?}", v, G.get_neighbors(v.clone()));
 
         G.remove_node(u_idx);
 
@@ -452,5 +592,6 @@ mod tests {
         }
         println!("\n");
         assert_eq!(G.get_order(), 2);
+        */
     }
 }

--- a/src-tauri/src/graph_p.rs
+++ b/src-tauri/src/graph_p.rs
@@ -540,58 +540,9 @@ mod tests {
 
         assert_eq!(G.get_size(), 3);
 
-        /*
-        for edge in G.get_edges() {
-            let node_u = G.g.node_weight(edge.u.clone()).unwrap();
-            let node_v = G.g.node_weight(edge.v.clone()).unwrap();
-            println!(
-                "Edge: (Name: {} - Degree Weight: {}) <-> (Name: {} - Degree Weight: {}) with weight {}",
-                node_u.name, node_u.optimal_weighted_degree, node_v.name, node_v.optimal_weighted_degree, edge.weight
-            );
-        }
-        println!("\n");
-        */
-
         G.update_edge(u.clone(), v.clone(), 11 as f64, None);
         G.remove_edge(u.clone(), w.clone(), None, Some(true));
 
         assert_eq!(G.get_size(), 2);
-
-        /*
-        for edge in G.get_edges() {
-            let node_u = G.g.node_weight(edge.u.clone()).unwrap();
-            let node_v = G.g.node_weight(edge.v.clone()).unwrap();
-            println!(
-                "Edge: (Name: {} - Degree Weight: {}) <-> (Name: {} - Degree Weight: {}) with weight {}",
-                node_u.name, node_u.optimal_weighted_degree, node_v.name, node_v.optimal_weighted_degree, edge.weight
-            );
-        }
-        println!("\n");
-
-
-        // Print the edges and nodes in the graph
-        println!("Edges: {:?}", G.get_edges());
-
-        let cum_sum = G.get_cumulative_edge_weights();
-        println!("Cumulative edge weights: {:?}", cum_sum);
-
-        println!("Degree of {}: {}", u, G.degree_of(u.clone()));
-        println!("Neighborhood of {}: {:?}", v, G.get_neighbors(v.clone()));
-
-        G.remove_node(u_idx);
-
-        println!("Nodes: {:?}", G.get_nodes());
-        println!("\n");
-        for edge in G.get_edges() {
-            let node_u = G.g.node_weight(edge.u.clone()).unwrap();
-            let node_v = G.g.node_weight(edge.v.clone()).unwrap();
-            println!(
-                "Edge: (Name: {} - Degree Weight: {}) <-> (Name: {} - Degree Weight: {}) with weight {}",
-                node_u.name, node_u.optimal_weighted_degree, node_v.name, node_v.optimal_weighted_degree, edge.weight
-            );
-        }
-        println!("\n");
-        assert_eq!(G.get_order(), 2);
-        */
     }
 }

--- a/src-tauri/src/graph_p.rs
+++ b/src-tauri/src/graph_p.rs
@@ -19,7 +19,7 @@ impl Node {
     }
 }
 
-// Add clone trait to Node
+/// Add clone trait to Node
 impl Clone for Node {
     fn clone(&self) -> Self {
         Node {
@@ -29,7 +29,7 @@ impl Clone for Node {
     }
 }
 
-// Add hash to Node so that we can use it as a key in a HashMap
+/// Add hash to Node so that we can use it as a key in a HashMap
 impl std::hash::Hash for Node {
     fn hash<H: std::hash::Hasher>(&self, state: &mut H) {
         self.name.hash(state);
@@ -67,7 +67,7 @@ impl Edge {
     }
 }
 
-// Add clone trait to Edge
+/// Add clone trait to Edge
 impl Clone for Edge {
     fn clone(&self) -> Self {
         Edge {
@@ -78,10 +78,10 @@ impl Clone for Edge {
     }
 }
 
-// Add eq operator to Edge
+/// Add eq operator to Edge
 impl std::cmp::Eq for Edge {}
 
-// Add equality operator to Edge
+/// Add equality operator to Edge
 impl PartialEq for Edge {
     fn eq(&self, other: &Self) -> bool {
         self.u == other.u && self.v == other.v
@@ -101,7 +101,7 @@ impl Graph {
     /// Creates a new graph and returns it.
     pub fn new() -> Graph {
         Graph {
-            g: StableUnGraph::<Node, Edge>::default(), // StableGraph::new(),
+            g: StableUnGraph::<Node, Edge>::default(),
             node_idx_map: HashMap::new(),
             edge_idx_map: HashMap::new(),
         }
@@ -264,6 +264,14 @@ impl Graph {
         self.change_node_opt_weight(v_idx_clone, weight - old_weight);
     }
 
+    /// Returns the weight of the edge between the two nodes.
+    ///
+    /// # Arguments
+    ///
+    /// * `u` - String identifier of the first node
+    /// * `v` - String identifier of the second node
+    /// * `parallel_edge_idx` - Optional usize index of the parallel edge we want to update.
+    /// * `get_all_parallel` - Optional bool flag to get weight sum of all parallel edges.
     pub fn get_edge_weight(
         &self,
         u: String,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,4 +1,5 @@
 mod articulation_point;
+mod globalmincut;
 mod graph_p;
 // Reference: https://rfdonnelly.github.io/posts/tauri-async-rust-process/
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -12,8 +12,6 @@ struct AsyncProcInputTx {
     inner: Mutex<mpsc::Sender<String>>,
 }
 
-mod graph_p;
-
 fn main() {
     tracing_subscriber::fmt::init();
 


### PR DESCRIPTION
This probabilistic algorithm finds the global mincut of a graph by contracting an edge until the order of graph is smaller than or equal to 2. The sum of weights of edges between these two nodes is the weight of global mincut. 

Note: The algorithm only returns the weight of mincut. I will need to find a way to recover which original vertex belongs to which cut.