### PR TITLE
Added module to merge and normalize edge weights

### DIFF
--- a/src-tauri/src/algorithms/stoer_wagner.rs
+++ b/src-tauri/src/algorithms/stoer_wagner.rs
@@ -124,8 +124,8 @@ mod tests {
         let nodes = vec![u, v, w, x, y, z, a, b];
         let (s, t) = recover_mincut(graph_sw, nodes);
 
-        println!("s: {:?}", s);
-        println!("t: {:?}", t);
+        assert!(s.len() + t.len() == 8);
+        assert!(s.iter().all(|x| !t.contains(x)));
 
         for _ in 0..100 {
             let graph_sw = &mut StoerWagnerGraph::new(g.clone());

--- a/src-tauri/src/algorithms/stoer_wagner.rs
+++ b/src-tauri/src/algorithms/stoer_wagner.rs
@@ -1,5 +1,7 @@
 #![allow(dead_code)]
 
+use std::collections::HashMap;
+
 use crate::aux_data_structures::{
     binary_heap::BinaryHeap, cut::Cut, stoer_wagner_ds::StoerWagnerGraph,
 };
@@ -49,6 +51,29 @@ pub fn stoer_wagner(graph: &mut StoerWagnerGraph) -> Cut {
     }
 }
 
+pub fn recover_mincut(
+    graph: &mut StoerWagnerGraph,
+    all_nodes: Vec<String>,
+) -> (Vec<String>, Vec<String>) {
+    let mut parent_map = HashMap::new();
+
+    for node in all_nodes {
+        let parent = graph.uf.find(node.clone());
+        let children = parent_map.entry(parent.clone()).or_insert(Vec::new());
+        children.push(node.clone());
+    }
+
+    // get the two keys in parent_map
+    let keys = Vec::from_iter(parent_map.keys());
+    let s = keys[0];
+    let t = keys[1];
+
+    return (
+        (*parent_map.get(s).unwrap().clone()).to_vec(),
+        (*parent_map.get(t).unwrap().clone()).to_vec(),
+    );
+}
+
 // Create a unit test for the stoer-wagner algorithm
 #[cfg(test)]
 mod tests {
@@ -92,6 +117,15 @@ mod tests {
         g.add_edge(y.clone(), b.clone(), 1.0);
 
         let mut correct_mincut_weight_count = 0;
+
+        let graph_sw = &mut StoerWagnerGraph::new(g.clone());
+        let _mincut = stoer_wagner(graph_sw);
+
+        let nodes = vec![u, v, w, x, y, z, a, b];
+        let (s, t) = recover_mincut(graph_sw, nodes);
+
+        println!("s: {:?}", s);
+        println!("t: {:?}", t);
 
         for _ in 0..100 {
             let graph_sw = &mut StoerWagnerGraph::new(g.clone());

--- a/src-tauri/src/aux_functions/edge_factory.rs
+++ b/src-tauri/src/aux_functions/edge_factory.rs
@@ -1,0 +1,86 @@
+use crate::graph::edge::Edge;
+use petgraph::graph::NodeIndex;
+
+pub fn edge_factory(
+    a: Vec<NodeIndex>,
+    b: Vec<NodeIndex>,
+    distance: Vec<f64>,
+    radio_s_quality: Vec<f64>,
+) -> Vec<Edge> {
+    let distance_min = distance.iter().fold(f64::INFINITY, |acc, &x| acc.min(x));
+    let distance_max = distance
+        .iter()
+        .fold(f64::NEG_INFINITY, |acc, &x| acc.max(x));
+    let radio_s_quality_min = radio_s_quality
+        .iter()
+        .fold(f64::INFINITY, |acc, &x| acc.min(x));
+    let radio_s_quality_max = radio_s_quality
+        .iter()
+        .fold(f64::NEG_INFINITY, |acc, &x| acc.max(x));
+
+    // create a vector of edges
+    let mut edges: Vec<Edge> = Vec::new();
+
+    for i in 0..a.len() {
+        let a = a[i].clone();
+        let b = b[i].clone();
+        let distance = distance[i];
+        let radio_s_quality = radio_s_quality[i];
+
+        // normalize the values
+        let weight = normalize_weight(
+            distance,
+            (distance_min, distance_max),
+            radio_s_quality,
+            (radio_s_quality_min, radio_s_quality_max),
+        );
+
+        // create an edge
+        let edge = Edge::new(a, b, weight);
+
+        // add the edge to the vector
+        edges.push(edge);
+    }
+
+    return edges;
+}
+
+pub fn normalize_weight(
+    distance: f64,
+    distance_minmax: (f64, f64),
+    radio_s_quality: f64,
+    radio_s_quality_minmax: (f64, f64),
+) -> f64 {
+    let distance_norm = (distance - distance_minmax.0) / (distance_minmax.1 - distance_minmax.0);
+    let radio_s_quality_norm = (radio_s_quality - radio_s_quality_minmax.0)
+        / (radio_s_quality_minmax.1 - radio_s_quality_minmax.0);
+    let weight = (0.5 * distance_norm) + (0.5 * radio_s_quality_norm);
+    return weight;
+}
+
+// Create a unit test for the Graph struct
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_edge_factory() {
+        let u = NodeIndex::new(0);
+        let v = NodeIndex::new(1);
+        let w = NodeIndex::new(2);
+        let x = NodeIndex::new(3);
+
+        let a = vec![u.clone(), u.clone(), w.clone(), v.clone()];
+        let b = vec![v.clone(), w.clone(), x.clone(), x.clone()];
+
+        let distance = vec![0.45, 0.67, 0.23, 1.2];
+        let radio_s_quality = vec![5.5, 3.12, 10.3, 2.7];
+
+        let edges = edge_factory(a, b, distance, radio_s_quality);
+
+        for edge in edges {
+            assert!(edge.weight != 0.0);
+            println!("{:?}", edge);
+        }
+    }
+}

--- a/src-tauri/src/aux_functions/edge_factory.rs
+++ b/src-tauri/src/aux_functions/edge_factory.rs
@@ -1,11 +1,26 @@
 use crate::graph::edge::Edge;
 use petgraph::graph::NodeIndex;
 
+/// Returns a list of edges
+///
+/// # Arguments
+///
+/// * `a` - List of first endpoints of edges
+/// * `b` - List of second endpoints of edges
+/// * `distances` - List of distances between nodes
+/// * `radio_s_quality` - List of radio signal qualities between nodes
+/// * `distance_weight` - Weight of distance in edge weight
+/// * `radio_s_quality_weight` - Weight of radio signal quality in edge weight
+///
+/// a, b, distance and radio_s_quality must have the same length and provide
+/// one-to-one mapping.
 pub fn edge_factory(
     a: Vec<NodeIndex>,
     b: Vec<NodeIndex>,
     distance: Vec<f64>,
     radio_s_quality: Vec<f64>,
+    distance_weight: Option<f64>,
+    radio_s_quality_weight: Option<f64>,
 ) -> Vec<Edge> {
     let distance_min = distance.iter().fold(f64::INFINITY, |acc, &x| acc.min(x));
     let distance_max = distance
@@ -21,6 +36,10 @@ pub fn edge_factory(
     // create a vector of edges
     let mut edges: Vec<Edge> = Vec::new();
 
+    // unwrap the weights
+    let distance_weight = distance_weight.unwrap_or(0.5);
+    let radio_s_quality_weight = radio_s_quality_weight.unwrap_or(0.5);
+
     for i in 0..a.len() {
         let a = a[i].clone();
         let b = b[i].clone();
@@ -31,14 +50,14 @@ pub fn edge_factory(
         let weight = normalize_weight(
             distance,
             (distance_min, distance_max),
+            distance_weight,
             radio_s_quality,
             (radio_s_quality_min, radio_s_quality_max),
+            radio_s_quality_weight,
         );
 
-        // create an edge
         let edge = Edge::new(a, b, weight);
 
-        // add the edge to the vector
         edges.push(edge);
     }
 
@@ -48,13 +67,16 @@ pub fn edge_factory(
 pub fn normalize_weight(
     distance: f64,
     distance_minmax: (f64, f64),
+    distance_weight: f64,
     radio_s_quality: f64,
     radio_s_quality_minmax: (f64, f64),
+    radio_s_quality_weight: f64,
 ) -> f64 {
     let distance_norm = (distance - distance_minmax.0) / (distance_minmax.1 - distance_minmax.0);
     let radio_s_quality_norm = (radio_s_quality - radio_s_quality_minmax.0)
         / (radio_s_quality_minmax.1 - radio_s_quality_minmax.0);
-    let weight = (0.5 * distance_norm) + (0.5 * radio_s_quality_norm);
+    let weight =
+        (distance_weight * distance_norm) + (radio_s_quality_weight * radio_s_quality_norm);
     return weight;
 }
 
@@ -76,11 +98,10 @@ mod tests {
         let distance = vec![0.45, 0.67, 0.23, 1.2];
         let radio_s_quality = vec![5.5, 3.12, 10.3, 2.7];
 
-        let edges = edge_factory(a, b, distance, radio_s_quality);
+        let edges = edge_factory(a, b, distance, radio_s_quality, None, None);
 
         for edge in edges {
             assert!(edge.weight != 0.0);
-            println!("{:?}", edge);
         }
     }
 }

--- a/src-tauri/src/aux_functions/mod.rs
+++ b/src-tauri/src/aux_functions/mod.rs
@@ -1,0 +1,1 @@
+pub(crate) mod edge_factory;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -1,5 +1,6 @@
 mod algorithms;
 mod aux_data_structures;
+mod aux_functions;
 mod graph;
 // Reference: https://rfdonnelly.github.io/posts/tauri-async-rust-process/
 


### PR DESCRIPTION
We have a vector of distance values, D, and a vector of radio signal qualities, R:

For every x in D: x = (x - min(D)) / (max(D) - min(D))
For every x in R: x = (x - min(R)) / (max(R) - min(R))

Now all values in both D and R are within range (0, 1). The edge weights are then:
weights = (0.5 x D) + (0.5 x R).

We use the module as follows:
```rust
let u = NodeIndex::new(0);
let v = NodeIndex::new(1);
let w = NodeIndex::new(2);
let x = NodeIndex::new(3);

let a = vec![u.clone(), u.clone(), w.clone(), v.clone()];
let b = vec![v.clone(), w.clone(), x.clone(), x.clone()];

let distance = vec![0.45, 0.67, 0.23, 1.2];
let radio_s_quality = vec![5.5, 3.12, 10.3, 2.7];

let edges = edge_factory(a, b, distance, radio_s_quality);
```

Closes #81 