### PR TITLE
Add another scaler to radio_signal_quality for a better scaling of the features

### DIFF
--- a/src-tauri/src/aux_functions/edge_factory.rs
+++ b/src-tauri/src/aux_functions/edge_factory.rs
@@ -73,7 +73,6 @@ pub fn edge_factory(
 }
 
 pub fn scale_rs_quality(radio_s_quality: f64) -> f64 {
-    // return 1 / ln(radio_s_quality + 1)
     return 1.0 / (1.0 + radio_s_quality).ln();
 }
 


### PR DESCRIPTION
High radio signal quality will usually come with low distance, so just scaling the features with minmax will negate the other's magnitude. This PR scales the radio_signal_quality with 1/ln(1+x) before minmax scaling so that large values of radio_signal_quality will result in small values and vice versa.