### PR TITLE
Added module to save snapshots of graph to file

### DIFF
--- a/src-tauri/src/algorithms/globalmincut.rs
+++ b/src-tauri/src/algorithms/globalmincut.rs
@@ -135,7 +135,7 @@ mod tests {
         G.add_edge(y.clone(), b.clone(), 1.0);
 
         let mut mincut_2 = 0;
-        for _ in 0..10000 {
+        for _ in 0..1000 {
             let order = G.get_order();
             let mincut = karger_stein_gmincut(&G.clone(), order as i32);
             if mincut == 1.0 {
@@ -143,6 +143,6 @@ mod tests {
             }
         }
 
-        println!("{} out of 10000", mincut_2);
+        println!("{} out of 1000", mincut_2);
     }
 }

--- a/src-tauri/src/aux_functions/edge_factory.rs
+++ b/src-tauri/src/aux_functions/edge_factory.rs
@@ -22,22 +22,24 @@ pub fn edge_factory(
     distance_weight: Option<f64>,
     radio_s_quality_weight: Option<f64>,
 ) -> Vec<Edge> {
-    let distance_min = distance.iter().fold(f64::INFINITY, |acc, &x| acc.min(x));
-    let distance_max = distance
+    let mut scaled_distances: Vec<f64> = Vec::new();
+
+    for dist in distance {
+        let scaled_dist = scale_distance(dist);
+        scaled_distances.push(scaled_dist);
+    }
+
+    let distance_min = scaled_distances
+        .iter()
+        .fold(f64::INFINITY, |acc, &x| acc.min(x));
+    let distance_max = scaled_distances
         .iter()
         .fold(f64::NEG_INFINITY, |acc, &x| acc.max(x));
 
-    let mut scaled_rs_quality_vec: Vec<f64> = Vec::new();
-
-    for rs_q in radio_s_quality {
-        let scaled_rs_q = scale_rs_quality(rs_q);
-        scaled_rs_quality_vec.push(scaled_rs_q);
-    }
-
-    let scaled_radio_s_quality_min = scaled_rs_quality_vec
+    let radio_s_quality_min = radio_s_quality
         .iter()
         .fold(f64::INFINITY, |acc, &x| acc.min(x));
-    let scaled_radio_s_quality_max = scaled_rs_quality_vec
+    let radio_s_quality_max = radio_s_quality
         .iter()
         .fold(f64::NEG_INFINITY, |acc, &x| acc.max(x));
 
@@ -51,8 +53,8 @@ pub fn edge_factory(
     for i in 0..a.len() {
         let a = a[i].clone();
         let b = b[i].clone();
-        let distance = distance[i];
-        let radio_s_quality = scaled_rs_quality_vec[i];
+        let distance = scaled_distances[i];
+        let radio_s_quality = radio_s_quality[i];
 
         // normalize the values
         let weight = normalize_weight(
@@ -60,7 +62,7 @@ pub fn edge_factory(
             (distance_min, distance_max),
             distance_weight,
             radio_s_quality,
-            (scaled_radio_s_quality_min, scaled_radio_s_quality_max),
+            (radio_s_quality_min, radio_s_quality_max),
             radio_s_quality_weight,
         );
 
@@ -72,8 +74,8 @@ pub fn edge_factory(
     return edges;
 }
 
-pub fn scale_rs_quality(radio_s_quality: f64) -> f64 {
-    return 1.0 / (1.0 + radio_s_quality).ln();
+pub fn scale_distance(distance: f64) -> f64 {
+    return 1.0 / (1.0 + distance).ln();
 }
 
 pub fn normalize_weight(

--- a/src-tauri/src/aux_functions/mod.rs
+++ b/src-tauri/src/aux_functions/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod edge_factory;
+pub(crate) mod take_snapshot;

--- a/src-tauri/src/aux_functions/take_snapshot.rs
+++ b/src-tauri/src/aux_functions/take_snapshot.rs
@@ -113,13 +113,11 @@ fn save_relative_ordering(graph: &Graph, file: &mut File) -> Result<(), Box<dyn 
 /// let _u_idx = G.add_node_from_struct(node_u);
 ///
 /// let mut node_v = Node::new(v.clone());
-/// node_v.latitude = 43.71584;
-/// node_v.longitude = -72.28239;
+/// node_v.set_gps(43.71584, -72.28239, 11.23);
 /// let _v_idx = G.add_node_from_struct(node_v);
 ///
 /// let mut node_w = Node::new(w.clone());
-/// node_w.latitude = 43.7114;
-/// node_w.longitude = -72.28332;
+/// node_w.set_gps(43.7114, -72.28332, 12.23)
 /// let _w_idx = G.add_node_from_struct(node_w);
 ///
 /// G.add_edge(u.clone(), v.clone(), 1 as f64);

--- a/src-tauri/src/aux_functions/take_snapshot.rs
+++ b/src-tauri/src/aux_functions/take_snapshot.rs
@@ -1,0 +1,142 @@
+use std::{error::Error, fs::File, io::Write};
+
+use crate::graph::graph_ds::Graph;
+
+/// Returns Haversine distance between 2 nodes using their lat and long
+/// https://en.wikipedia.org/wiki/Haversine_formula
+///
+/// # Arguments
+///
+/// * `lat1` - latitude of node 1
+/// * `long1` - longitude of node 1
+/// * `lat2` - latitude of node 2
+/// * `long2` - longitude of node 2
+fn haversine_distance(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
+    let r = 6371.0; // radius of the earth in km
+    let d_lat = (lat2 - lat1).to_radians();
+    let d_lon = (lon2 - lon1).to_radians();
+    let a = (d_lat / 2.0).sin().powi(2)
+        + (d_lon / 2.0).sin().powi(2) * lat1.to_radians().cos() * lat2.to_radians().cos();
+    let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
+    r * c
+}
+
+fn save_relative_ordering(graph: &Graph, file: &mut File) -> Result<(), Box<dyn Error>> {
+    let mut nodes = graph.get_nodes().clone();
+
+    let smallest_longitude_node = nodes.iter().fold(nodes[0].clone(), |acc, node| {
+        if node.longitude < acc.longitude {
+            node.clone()
+        } else {
+            acc
+        }
+    });
+
+    // sort nodes by their haversine distance to the smallest longitude node
+    nodes.sort_by(|a, b| {
+        let a_distance = haversine_distance(
+            smallest_longitude_node.latitude,
+            smallest_longitude_node.longitude,
+            a.latitude,
+            a.longitude,
+        );
+        let b_distance = haversine_distance(
+            smallest_longitude_node.latitude,
+            smallest_longitude_node.longitude,
+            b.latitude,
+            b.longitude,
+        );
+        a_distance.partial_cmp(&b_distance).unwrap()
+    });
+
+    let mut ordering: String = "".to_owned();
+    let mut ordering_counter = 0;
+    let order = graph.get_order();
+
+    ordering.push_str(order.to_string().as_str());
+    ordering.push_str("\n");
+
+    for node in nodes {
+        ordering.push_str(&node.name);
+        ordering.push_str(" ");
+        ordering.push_str(ordering_counter.to_string().as_str());
+        ordering_counter += 1;
+        ordering.push_str("\n");
+    }
+
+    ordering.push_str("\n");
+
+    file.write_all(ordering.as_bytes())
+        .expect("Unable to write data");
+
+    Ok(())
+}
+
+/// Saves the graph to a file
+///
+/// # Arguments
+///
+/// * `graph` - the graph to save
+/// * `file_name` - the file to save the graph to
+///
+/// # Test
+///
+/// ```rust
+/// use graph::graph_ds::Graph;
+/// let mut G = Graph::new();
+/// let u: String = "u".to_string();
+/// let v: String = "v".to_string();
+/// let w: String = "w".to_string();
+///
+/// let mut node_u = Node::new(u.clone());
+/// node_u.latitude = 43.71489;
+/// node_u.longitude = -72.28486;
+/// let _u_idx = G.add_node_from_struct(node_u);
+///
+/// let mut node_v = Node::new(v.clone());
+/// node_v.latitude = 43.71584;
+/// node_v.longitude = -72.28239;
+/// let _v_idx = G.add_node_from_struct(node_v);
+///
+/// let mut node_w = Node::new(w.clone());
+/// node_w.latitude = 43.7114;
+/// node_w.longitude = -72.28332;
+/// let _w_idx = G.add_node_from_struct(node_w);
+///
+/// G.add_edge(u.clone(), v.clone(), 1 as f64);
+/// G.add_edge(u.clone(), w.clone(), 1 as f64);
+/// G.add_edge(v.clone(), w.clone(), 35 as f64);
+///
+/// let file_name = "test_graph.txt";
+/// save_graph_to_txt_file(&G, file_name).unwrap();
+/// ```
+pub fn save_graph_to_txt_file(graph: &Graph, file_name: &str) -> Result<(), Box<dyn Error>> {
+    let mut file = File::create(file_name)?;
+
+    save_relative_ordering(graph, &mut file)?;
+
+    let mut edges_rep: String = "".to_owned();
+
+    for edge in graph.get_edges() {
+        let u_idx = edge.get_u();
+        let node_u = graph.get_node(u_idx);
+        edges_rep.push_str(&node_u.name);
+        edges_rep.push_str(" ");
+
+        let b_idx = edge.get_v();
+        let node_b = graph.get_node(b_idx);
+        edges_rep.push_str(&node_b.name);
+        edges_rep.push_str(" ");
+
+        let weight = edge.get_weight();
+        edges_rep.push_str(&weight.to_string());
+        edges_rep.push_str("\n");
+    }
+
+    edges_rep.pop();
+
+    file.write_all(edges_rep.as_bytes())
+        .expect("Unable to write data");
+
+    Ok(())
+}

--- a/src-tauri/src/aux_functions/take_snapshot.rs
+++ b/src-tauri/src/aux_functions/take_snapshot.rs
@@ -8,9 +8,9 @@ use crate::graph::graph_ds::Graph;
 /// # Arguments
 ///
 /// * `lat1` - latitude of node 1
-/// * `long1` - longitude of node 1
+/// * `lon1` - longitude of node 1
 /// * `lat2` - latitude of node 2
-/// * `long2` - longitude of node 2
+/// * `lon2` - longitude of node 2
 fn haversine_distance(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
     let r = 6371.0; // radius of the earth in km
     let d_lat = (lat2 - lat1).to_radians();
@@ -19,6 +19,22 @@ fn haversine_distance(lat1: f64, lon1: f64, lat2: f64, lon2: f64) -> f64 {
         + (d_lon / 2.0).sin().powi(2) * lat1.to_radians().cos() * lat2.to_radians().cos();
     let c = 2.0 * a.sqrt().atan2((1.0 - a).sqrt());
     r * c
+}
+
+/// Returns total distance between 2 nodes using euclidean of haversine and altitude difference.
+///
+/// # Arguments
+///
+/// * `lat1` - latitude of node 1
+/// * `lon1` - longitude of node 1
+/// * `alt1` - altitude of node 1
+/// * `lat2` - latitude of node 2
+/// * `lon2` - longitude of node 2
+/// * `alt2` - altitude of node 2
+fn total_distance(lat1: f64, lon1: f64, alt1: f64, lat2: f64, lon2: f64, alt2: f64) -> f64 {
+    let haversine_distance = haversine_distance(lat1, lon1, lat2, lon2).powi(2);
+    let alt_difference = (alt1 - alt2).powi(2);
+    (haversine_distance + alt_difference).sqrt()
 }
 
 fn save_relative_ordering(graph: &Graph, file: &mut File) -> Result<(), Box<dyn Error>> {
@@ -34,17 +50,21 @@ fn save_relative_ordering(graph: &Graph, file: &mut File) -> Result<(), Box<dyn 
 
     // sort nodes by their haversine distance to the smallest longitude node
     nodes.sort_by(|a, b| {
-        let a_distance = haversine_distance(
+        let a_distance = total_distance(
             smallest_longitude_node.latitude,
             smallest_longitude_node.longitude,
+            smallest_longitude_node.altitude,
             a.latitude,
             a.longitude,
+            a.altitude,
         );
-        let b_distance = haversine_distance(
+        let b_distance = total_distance(
             smallest_longitude_node.latitude,
             smallest_longitude_node.longitude,
+            smallest_longitude_node.altitude,
             b.latitude,
             b.longitude,
+            b.altitude,
         );
         a_distance.partial_cmp(&b_distance).unwrap()
     });

--- a/src-tauri/src/aux_functions/take_snapshot.rs
+++ b/src-tauri/src/aux_functions/take_snapshot.rs
@@ -57,14 +57,13 @@ fn save_relative_ordering(graph: &Graph, file: &mut File) -> Result<(), Box<dyn 
     ordering.push_str("\n");
 
     for node in nodes {
+        ordering.push_str("O: ");
         ordering.push_str(&node.name);
         ordering.push_str(" ");
         ordering.push_str(ordering_counter.to_string().as_str());
         ordering_counter += 1;
         ordering.push_str("\n");
     }
-
-    ordering.push_str("\n");
 
     file.write_all(ordering.as_bytes())
         .expect("Unable to write data");
@@ -118,6 +117,7 @@ pub fn save_graph_to_txt_file(graph: &Graph, file_name: &str) -> Result<(), Box<
     let mut edges_rep: String = "".to_owned();
 
     for edge in graph.get_edges() {
+        edges_rep.push_str("E: ");
         let u_idx = edge.get_u();
         let node_u = graph.get_node(u_idx);
         edges_rep.push_str(&node_u.name);

--- a/src-tauri/src/graph/edge.rs
+++ b/src-tauri/src/graph/edge.rs
@@ -17,6 +17,18 @@ impl Edge {
     pub fn new(u: petgraph::graph::NodeIndex, v: petgraph::graph::NodeIndex, weight: f64) -> Edge {
         Edge { u, v, weight }
     }
+
+    pub fn get_u(&self) -> petgraph::graph::NodeIndex {
+        self.u
+    }
+
+    pub fn get_v(&self) -> petgraph::graph::NodeIndex {
+        self.v
+    }
+
+    pub fn get_weight(&self) -> f64 {
+        self.weight
+    }
 }
 
 /// Add clone trait to Edge

--- a/src-tauri/src/graph/node.rs
+++ b/src-tauri/src/graph/node.rs
@@ -2,6 +2,8 @@
 pub struct Node {
     pub name: String,
     pub optimal_weighted_degree: f64,
+    pub longitude: f64,
+    pub latitude: f64,
 }
 
 impl Node {
@@ -9,7 +11,14 @@ impl Node {
         Node {
             name,
             optimal_weighted_degree: 0.0,
+            longitude: 0.0,
+            latitude: 0.0,
         }
+    }
+
+    pub fn set_gps(&mut self, longitude: f64, latitude: f64) {
+        self.longitude = longitude;
+        self.latitude = latitude;
     }
 }
 
@@ -19,6 +28,8 @@ impl Clone for Node {
         Node {
             name: self.name.clone(),
             optimal_weighted_degree: self.optimal_weighted_degree,
+            longitude: self.longitude,
+            latitude: self.latitude,
         }
     }
 }

--- a/src-tauri/src/graph/node.rs
+++ b/src-tauri/src/graph/node.rs
@@ -4,6 +4,7 @@ pub struct Node {
     pub optimal_weighted_degree: f64,
     pub longitude: f64,
     pub latitude: f64,
+    pub altitude: f64,
 }
 
 impl Node {
@@ -13,12 +14,14 @@ impl Node {
             optimal_weighted_degree: 0.0,
             longitude: 0.0,
             latitude: 0.0,
+            altitude: 0.0,
         }
     }
 
-    pub fn set_gps(&mut self, longitude: f64, latitude: f64) {
+    pub fn set_gps(&mut self, longitude: f64, latitude: f64, altitude: f64) {
         self.longitude = longitude;
         self.latitude = latitude;
+        self.altitude = altitude;
     }
 }
 
@@ -30,6 +33,7 @@ impl Clone for Node {
             optimal_weighted_degree: self.optimal_weighted_degree,
             longitude: self.longitude,
             latitude: self.latitude,
+            altitude: self.altitude,
         }
     }
 }


### PR DESCRIPTION
This module will take a snapshot of the graph in intervals and save it to a txt file in the following format to be used in #94:

```txt

4
O: a 0
O: b 1
O: c 2
O: d 3
E: a b 0.55
E: a c 0.34
E: b d 0.65
E: b c 0.33
```

First line is the number of nodes in the graph.
Next, for each node, we save its relative position in the graph where 0 is the leftmost node position and 2 is the rightmost position in this graph. "O:" means the line pertains to ordering of graph.
Finally, we save edge per line, for all edges. "E:" means the line pertains to edge of graph.

Currently draft because it needs a better way of selecting leftmost node.