### PR TITLE
[to be discarded] Add Protobuf to Graph Dataflow

### DIFF
--- a/README.md
+++ b/README.md
@@ -38,4 +38,4 @@ The following commands can be used to develop on this codebase. Note that it is 
 - `pnpm run ui:format` - Formats the UI codebase using [Prettier](https://prettier.io/) and [ESLint](https://eslint.org/)
 - `pnpm run ui:test` - Runs UI test suite using [Jest](https://jestjs.io/)
 - `pnpm run rust:dev` - Starts the desktop application in development mode, allowing for hot reloading of UI and Rust code
-- `pnpm run rust:test` - Runs backend tests on the Rust codebase directory (`/src-tauri`)
+- `pnpm run rust:test` - Runs backend tests on the Rust codebase directory (`/src-tauri`) Add `-- --show-output` to show printlns.

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -8,6 +8,7 @@ fn main() -> std::io::Result<()> {
 
     let protobufs_dir = "protobufs";
     let mut protos = vec![];
+    println!("Compiling protobufs to rust...\n");
 
     for entry in WalkDir::new("protobufs")
         .into_iter()

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -8,7 +8,6 @@ fn main() -> std::io::Result<()> {
 
     let protobufs_dir = "protobufs";
     let mut protos = vec![];
-    println!("Compiling protobufs to rust...\n");
 
     for entry in WalkDir::new("protobufs")
         .into_iter()

--- a/src-tauri/src/algorithms/mod.rs
+++ b/src-tauri/src/algorithms/mod.rs
@@ -1,3 +1,3 @@
-mod articulation_point;
+pub mod articulation_point;
 mod globalmincut;
 mod stoer_wagner;

--- a/src-tauri/src/aux_functions/mod.rs
+++ b/src-tauri/src/aux_functions/mod.rs
@@ -1,1 +1,2 @@
 pub(crate) mod edge_factory;
+pub(crate) mod neighbor_factory;

--- a/src-tauri/src/aux_functions/neighbor_factory.rs
+++ b/src-tauri/src/aux_functions/neighbor_factory.rs
@@ -1,15 +1,71 @@
 use crate::graph::edge::Edge;
 use crate::graph::graph_ds::Graph;
 use crate::graph::node::Node;
-use app::protobufs::{Data, Position};
+use app::protobufs::{Data, NeighborInfo, Position, User};
 use petgraph::graph::NodeIndex;
 
 // Take in data from the frontend in protobuf form, parse it, run algorithms on it, and
 // send it back.
 
 #[tauri::command]
-pub fn run_algorithm(data: Data) -> Result<Data, String> {
-    Ok(data)
+pub fn run_algorithm(data: Vec<Data>) -> Result<Data, String> {
+    // Create a graph
+    // Run the specified algorithm on the graph
+    // Return the result of the algorithm to the frontend in the specified data structure
+
+    // We need to define the data fields of the response values (simply a point cloud?)
+
+    // let mut graph = Graph::new();
+
+    // // Add nodes
+    // for node in data {
+    //     let node_name = node.name;
+    //     let node_position = node.position.unwrap();
+    //     let node_position_x = node_position.x;
+    //     let node_position_y = node_position.y;
+    //     let node_position_z = node_position.z;
+    //     let node_position = Position {
+    //         x: node_position_x,
+    //         y: node_position_y,
+    //         z: node_position_z,
+    //     };
+    //     let node_position = Some(node_position);
+    //     let node = Node {
+    //         name: node_name,
+    //         position: node_position,
+    //     };
+    //     graph.add_node(node);
+    // }
+
+    // // Add edges
+    // for node in data {
+    //     let node_name = node.name;
+    //     let node_neighbors = node.neighbors.unwrap();
+    //     for neighbor in node_neighbors {
+    //         let neighbor_name = neighbor.name;
+    //         let neighbor_weight = neighbor.weight;
+    //         let edge = Edge {
+    //             name: neighbor_name,
+    //             weight: neighbor_weight,
+    //         };
+    //         graph.add_edge(node_name.clone(), edge);
+    //     }
+    // }
+
+    // // Run the algorithm
+    // let result = articulation_point(graph);
+
+    // // Convert the result to protobuf form
+    // let mut result_data = Data::new();
+    // let mut result_data_neighbors = Vec::new();
+    // for node in result {
+    //     let mut result_data_neighbor = NeighborInfo::new();
+    //     result_data_neighbor.name = node.name;
+    //     result_data_neighbors.push(result_data_neighbor);
+    // }
+    // result_data.neighbors = Some(result_data_neighbors);
+
+    // Ok(result_data)
 }
 
 /*

--- a/src-tauri/src/aux_functions/neighbor_factory.rs
+++ b/src-tauri/src/aux_functions/neighbor_factory.rs
@@ -3,70 +3,46 @@ use crate::graph::graph_ds::Graph;
 use crate::graph::node::Node;
 use app::protobufs::{Data, NeighborInfo, Position, User};
 use petgraph::graph::NodeIndex;
+use 
 
 // Take in data from the frontend in protobuf form, parse it, run algorithms on it, and
 // send it back.
 
-#[tauri::command]
-pub fn run_algorithm(data: Vec<Data>) -> Result<Data, String> {
+#[tauri::command]`
+pub fn run_algorithm(data: Vec<NeighborInfo>, algorithm: String) -> Result<Vec<Point>, String> {
     // Create a graph
-    // Run the specified algorithm on the graph
+    let mut graph = populate_graph(data);
+    
+    // Run the specified algorithm on the graph (based on the input)
+    let result = articulation_point(graph);
+
     // Return the result of the algorithm to the frontend in the specified data structure
-
     // We need to define the data fields of the response values (simply a point cloud?)
-
-    // let mut graph = Graph::new();
-
-    // // Add nodes
-    // for node in data {
-    //     let node_name = node.name;
-    //     let node_position = node.position.unwrap();
-    //     let node_position_x = node_position.x;
-    //     let node_position_y = node_position.y;
-    //     let node_position_z = node_position.z;
-    //     let node_position = Position {
-    //         x: node_position_x,
-    //         y: node_position_y,
-    //         z: node_position_z,
-    //     };
-    //     let node_position = Some(node_position);
-    //     let node = Node {
-    //         name: node_name,
-    //         position: node_position,
-    //     };
-    //     graph.add_node(node);
-    // }
-
-    // // Add edges
-    // for node in data {
-    //     let node_name = node.name;
-    //     let node_neighbors = node.neighbors.unwrap();
-    //     for neighbor in node_neighbors {
-    //         let neighbor_name = neighbor.name;
-    //         let neighbor_weight = neighbor.weight;
-    //         let edge = Edge {
-    //             name: neighbor_name,
-    //             weight: neighbor_weight,
-    //         };
-    //         graph.add_edge(node_name.clone(), edge);
-    //     }
-    // }
-
-    // // Run the algorithm
-    // let result = articulation_point(graph);
-
-    // // Convert the result to protobuf form
-    // let mut result_data = Data::new();
-    // let mut result_data_neighbors = Vec::new();
-    // for node in result {
-    //     let mut result_data_neighbor = NeighborInfo::new();
-    //     result_data_neighbor.name = node.name;
-    //     result_data_neighbors.push(result_data_neighbor);
-    // }
-    // result_data.neighbors = Some(result_data_neighbors);
-
-    // Ok(result_data)
+    Vec<Point> result = Vec<Point>::new();
+    result = create_point_cloud_from_graph(graph);
+    return result;
 }
+
+
+pub fn create_point_cloud_from_graph(graph: Graph) -> Vec<Point> {
+    // Create a point cloud from the graph
+    // Return the point cloud
+    Vec<Point> point_cloud = Vec<Point>::new();
+    for node in graph.get_nodes() {
+        let node_position = node.position.unwrap();
+        let node_position_x = node_position.x;
+        let node_position_y = node_position.y;
+        let node_position_z = node_position.z;
+        let point = Point {
+            x: node_position_x,
+            y: node_position_y,
+            z: node_position_z,
+        };
+        point_cloud.push(point);
+    }
+    return point_cloud;
+}
+
 
 /*
 * When we create a graph, we need a list of all nodes and each of their neighbor lists.
@@ -75,22 +51,43 @@ pub fn run_algorithm(data: Vec<Data>) -> Result<Data, String> {
 *
 * We will use it to calculate the pythagorean distance between nodes, and use this to create their edge weights.
  */
-pub fn create_graph(data: Data) -> Graph {
-    let mut graph = Graph::new();
-    for node in data.nodes {
-        graph.add_node(node.id);
+pub fn populate_graph(data: Vec<NeighborInfo>) -> Graph {
+  let mut graph = Graph::new();
+  let mut edge_left_endpoints = Vec<NodeIndex>::new();
+  let mut edge_right_endpoints = Vec<NodeIndex>::new();
+  let mut distances = Vec<f64>::new();
+  let mut radio_quality = Vec<f64>::new();
+  // for each node we have info on, add it and all its neighbors to the graph
+  for neighbor_info in data {
+    // Add node
+    if !graph.contains_node(neighbor.name) {
+      let node = Node::new(neighbor_info.user.name, neighbor_info.user.position);
+      graph.add_node(node);
     }
-    for edge in data.edges {
-        graph.add_edge(edge.source, edge.target, edge.weight);
+    // Add neighbors
+    for neighbor in neighbor_info.neighbors {
+      if !graph.contains_node(neighbor.name) {
+        let neighbor_node = Node::new(neighbor.name, neighbor.position);
+        edge_left_endpoints.add(neighbor_node);
+        edge_right_endpoints.add(neighbor_info);
+        let edge = Edge::new(neighbor_node, neighbor.weight);
+        graph.add_edge(edge);
+      }
     }
-    return graph;
+  }
+  return graph;
 }
 
-// pass in protobufs and do things with them; e.g. run different algorithms with different data
-pub fn print_protobuf(data: Data) -> Result<Data, String> {
+// printing utility for testing
+fn print_protobuf(data: Data) -> Result<Data, String> {
     // let mut data = serde_protobuf::from_bytes::<Data>(&data).unwrap();
     println!("data: {:?}", data);
     return Ok(data);
+}
+
+fn print_graph(graph: Graph) -> Result<Graph, String> {
+    println!("graph: {:?}", graph.to_string());
+    return Ok(graph);
 }
 
 #[cfg(test)]

--- a/src-tauri/src/aux_functions/neighbor_factory.rs
+++ b/src-tauri/src/aux_functions/neighbor_factory.rs
@@ -1,48 +1,42 @@
+use super::edge_factory::edge_factory;
+use crate::algorithms::articulation_point::articulation_point;
 use crate::graph::edge::Edge;
 use crate::graph::graph_ds::Graph;
 use crate::graph::node::Node;
-use app::protobufs::{Data, NeighborInfo, Position, User};
+use app::protobufs::{Data, NeighborInfo};
 use petgraph::graph::NodeIndex;
-use 
+
+pub struct Point {
+    x: i32,
+    y: i32,
+}
 
 // Take in data from the frontend in protobuf form, parse it, run algorithms on it, and
 // send it back.
-
-#[tauri::command]`
+#[tauri::command]
 pub fn run_algorithm(data: Vec<NeighborInfo>, algorithm: String) -> Result<Vec<Point>, String> {
     // Create a graph
     let mut graph = populate_graph(data);
-    
+
     // Run the specified algorithm on the graph (based on the input)
-    let result = articulation_point(graph);
+    let result = articulation_point(graph.clone());
 
     // Return the result of the algorithm to the frontend in the specified data structure
     // We need to define the data fields of the response values (simply a point cloud?)
-    Vec<Point> result = Vec<Point>::new();
-    result = create_point_cloud_from_graph(graph);
-    return result;
+    let result = create_point_cloud_from_graph(graph);
+
+    return Ok(result);
 }
 
-
+/*
+* Do postprocessing of the algorithm result and return it in the format the frontend expects.
+* We'll also need position data for each node and an ID.
+*/
 pub fn create_point_cloud_from_graph(graph: Graph) -> Vec<Point> {
-    // Create a point cloud from the graph
-    // Return the point cloud
-    Vec<Point> point_cloud = Vec<Point>::new();
-    for node in graph.get_nodes() {
-        let node_position = node.position.unwrap();
-        let node_position_x = node_position.x;
-        let node_position_y = node_position.y;
-        let node_position_z = node_position.z;
-        let point = Point {
-            x: node_position_x,
-            y: node_position_y,
-            z: node_position_z,
-        };
-        point_cloud.push(point);
-    }
+    let point_cloud = Vec::<Point>::new();
+    // TODO:
     return point_cloud;
 }
-
 
 /*
 * When we create a graph, we need a list of all nodes and each of their neighbor lists.
@@ -52,30 +46,60 @@ pub fn create_point_cloud_from_graph(graph: Graph) -> Vec<Point> {
 * We will use it to calculate the pythagorean distance between nodes, and use this to create their edge weights.
  */
 pub fn populate_graph(data: Vec<NeighborInfo>) -> Graph {
-  let mut graph = Graph::new();
-  let mut edge_left_endpoints = Vec<NodeIndex>::new();
-  let mut edge_right_endpoints = Vec<NodeIndex>::new();
-  let mut distances = Vec<f64>::new();
-  let mut radio_quality = Vec<f64>::new();
-  // for each node we have info on, add it and all its neighbors to the graph
-  for neighbor_info in data {
-    // Add node
-    if !graph.contains_node(neighbor.name) {
-      let node = Node::new(neighbor_info.user.name, neighbor_info.user.position);
-      graph.add_node(node);
+    let mut graph = Graph::new();
+    let mut edge_left_endpoints = Vec::<NodeIndex>::new();
+    let mut edge_right_endpoints = Vec::<NodeIndex>::new();
+    let mut distances = Vec::<f64>::new();
+    let radio_quality = Vec::<f64>::new();
+    // for each node we have info on, add it and all its neighbors to the graph
+    for mut neighbor_info in data {
+        // Do basic none checks
+        if neighbor_info.user == None || neighbor_info.position == None {
+            println!("Error: Node info or position is None\n");
+            return graph;
+        }
+        // Get node info
+        let node_id = &neighbor_info.user.as_ref().unwrap().id;
+        let node_x = neighbor_info.position.as_ref().unwrap().latitude_i;
+        let node_y = neighbor_info.position.as_ref().unwrap().longitude_i;
+        if !graph
+            .node_idx_map
+            .contains_key(&(node_id.clone() as String))
+        {
+            graph.add_node(node_id.clone() as String);
+        }
+
+        for i in 0..neighbor_info.num_neighbors {
+            let neighbor_id = neighbor_info.neighbor_ids.pop().unwrap().id;
+            let neighbor_x = neighbor_info.neighbor_positions.pop().unwrap().latitude_i;
+            let neighbor_y = neighbor_info.neighbor_positions.pop().unwrap().longitude_i;
+            // TODO: risky unwrap, needs error checking
+            let x_distance_between = node_x - neighbor_x;
+            let y_distance_between = node_y - neighbor_y;
+            let distance_between =
+                ((x_distance_between.pow(2) + y_distance_between.pow(2)) as f64).sqrt();
+            if !graph.node_idx_map.contains_key(&neighbor_id) {
+                graph.add_node(neighbor_id.clone());
+            }
+            edge_left_endpoints.push(graph.get_node_idx(node_id.clone()));
+            edge_right_endpoints.push(graph.get_node_idx(neighbor_id.clone()));
+            distances.push(distance_between);
+            //TODO: radio quality
+        }
     }
-    // Add neighbors
-    for neighbor in neighbor_info.neighbors {
-      if !graph.contains_node(neighbor.name) {
-        let neighbor_node = Node::new(neighbor.name, neighbor.position);
-        edge_left_endpoints.add(neighbor_node);
-        edge_right_endpoints.add(neighbor_info);
-        let edge = Edge::new(neighbor_node, neighbor.weight);
-        graph.add_edge(edge);
-      }
+
+    let edges = edge_factory(
+        edge_left_endpoints,
+        edge_right_endpoints,
+        distances,
+        radio_quality,
+        None,
+        None,
+    );
+    for edge in edges {
+        graph.g.add_edge(edge.u, edge.v, edge);
     }
-  }
-  return graph;
+    graph
 }
 
 // printing utility for testing
@@ -83,11 +107,6 @@ fn print_protobuf(data: Data) -> Result<Data, String> {
     // let mut data = serde_protobuf::from_bytes::<Data>(&data).unwrap();
     println!("data: {:?}", data);
     return Ok(data);
-}
-
-fn print_graph(graph: Graph) -> Result<Graph, String> {
-    println!("graph: {:?}", graph.to_string());
-    return Ok(graph);
 }
 
 #[cfg(test)]

--- a/src-tauri/src/aux_functions/neighbor_factory.rs
+++ b/src-tauri/src/aux_functions/neighbor_factory.rs
@@ -1,0 +1,58 @@
+//use crate::serde::serde_protobuf;
+use app::protobufs::{Data, PortNum};
+// use serde::serde_protobuf::{Deserialize, Serialize};
+//use app::protobufs::mesh::{Data, HardwareModel, Position};
+
+// Take in data from the frontend in protobuf form, parse it, run algorithms on it, and
+// send it back.
+
+#[tauri::command]
+// pass in protobufs and do things with them; e.g. run different algorithms with different data
+pub fn print_protobuf(data: Data) -> Result<Data, String> {
+    // let mut data = serde_protobuf::from_bytes::<Data>(&data).unwrap();
+    println!("data: {:?}", data);
+    return Ok(data);
+}
+
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_protobuf_initialization() {
+        println!("here goes nothing");
+        let mut data = vec![1u8, 2, 3];
+        //let portnum = PortNum::UNKNOWN_APP;
+        let portnum = PortNum::default();
+        let mut payload = Data {
+            portnum: 0, //portnum,
+            payload: data,
+            want_response: false,
+            dest: 0,
+            source: 1,
+            request_id: 0,
+            reply_id: 1,
+            emoji: 0,
+        };
+        //   protobuf.portnum = 0;
+        //   protobuf.payload = "Hi".to_string();
+        //   protobuf.want_response = true;
+        //   protobuf.dest = 1;
+        //   protobuf.source = 2;
+        //   protobuf.request_id = 0;
+        //   protobuf.reply_id = 0;
+        //   protobuf.emoji = false;
+        // );
+        print_protobuf(payload);
+        // let mut data = Data::new();`
+        // let mut hardware_model = HardwareModel::new();
+        // let mut position = Position::new();
+        // position.set_x(1.0);
+        // position.set_y(1.0);
+        // position.set_z(1.0);
+        // hardware_model.set_position(position);
+        // data.set_hardware_model(hardware_model);
+        // let data = serde_protobuf::to_vec(&data).unwrap();
+        // print_protobuf(data).unwrap();
+    }
+}

--- a/src-tauri/src/aux_functions/neighbor_factory.rs
+++ b/src-tauri/src/aux_functions/neighbor_factory.rs
@@ -1,7 +1,7 @@
 use crate::graph::edge::Edge;
 use crate::graph::graph_ds::Graph;
 use crate::graph::node::Node;
-use app::protobufs::Data;
+use app::protobufs::{Data, Position};
 use petgraph::graph::NodeIndex;
 
 // Take in data from the frontend in protobuf form, parse it, run algorithms on it, and


### PR DESCRIPTION
**The Neighbor Problem**

This pull request addresses the problem of centralizing a decentralized mesh network. While we could (and do) append route info to packets, this would provide us with knowledge of only the shortest paths in the network. In a rescue situation, where reliability is paramount, we need a better protocol. We can break this down into two steps: 

1. Neighbor discovery
2. Transmission to coordinator

For the first step, all nodes in the network need to send out a simple packet to their neighbors (1 hop away) to establish connection. If neighbor lists are known, we skip this step and send info directly to the coordinator. 

This PR assumes that we get info in the form of N protobufs, where N is the number of connected nodes in the network. Each protobuf contains the neighbor info for each node - IDs and positions. We start with that and use it to create the edges on our graph. 

(This information could also be encoded in regular packet form, removing the need for a new protobuf. If so, it's easy enough to delete our `neighbors.proto` file.)