### PR TITLE
Move Sidebar State into Redux

### DIFF
--- a/src/components/Map/MapView.tsx
+++ b/src/components/Map/MapView.tsx
@@ -8,13 +8,30 @@ import NodeSearchDock from "@components/NodeSearch/NodeSearchDock";
 
 import { selectActiveNode, selectAllNodes } from "@features/device/deviceSelectors";
 import { deviceSliceActions } from "@features/device/deviceSlice";
+import { selectActiveSidebarPanel } from "@features/panels/panelsSelectors";
+import type { ActiveSidebarPanel } from "@features/panels/panelsSlice";
 
 import "./MapView.css";
+
+interface _IMapViewLeftPanel {
+  activeSidebarPanel: ActiveSidebarPanel
+}
+
+const _MapViewLeftPanel = ({ activeSidebarPanel }: _IMapViewLeftPanel) => {
+  switch (activeSidebarPanel) {
+    case "map":
+      return <NodeSearchDock />;
+
+    default:
+      return <></>;
+  }
+}
 
 export const MapView = () => {
   const dispatch = useDispatch();
   const nodes = useSelector(selectAllNodes());
   const activeNodeId = useSelector(selectActiveNode());
+  const activeSidebarPanel = useSelector(selectActiveSidebarPanel());
 
   const updateActiveNode = (nodeId: number | null) => {
     dispatch(deviceSliceActions.setActiveNode(nodeId));
@@ -40,7 +57,7 @@ export const MapView = () => {
           />
         ))}
 
-        <NodeSearchDock />
+        <_MapViewLeftPanel activeSidebarPanel={activeSidebarPanel} />
       </Map>
     </div>
   );

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -1,6 +1,6 @@
-import React, { useEffect, useState } from "react";
-import LogoWhiteSVG from "@app/assets/Mesh_Logo_White.svg";
-import SidebarIcon from "@components/Sidebar/SidebarIcon";
+import React, { useEffect } from "react";
+import { useDispatch, useSelector } from "react-redux";
+
 import {
   ChatBubbleBottomCenterTextIcon,
   MagnifyingGlassIcon,
@@ -8,23 +8,18 @@ import {
   Cog8ToothIcon,
   LinkIcon,
 } from "@heroicons/react/24/outline";
-import { useDispatch, useSelector } from "react-redux";
+import LogoWhiteSVG from "@app/assets/Mesh_Logo_White.svg";
+
+import SidebarIcon from "@components/Sidebar/SidebarIcon";
 import { selectAllDevices } from "@app/features/device/deviceSelectors";
 import { createDeviceAction } from "@features/device/deviceActions";
-
-export enum ActiveTab {
-  MAP,
-  CHAT,
-  INFO,
-  SETTINGS,
-  NONE
-}
+import { selectActiveSidebarPanel } from "@features/panels/panelsSelectors";
+import { ActiveSidebarPanel, panelsSliceActions } from "@features/panels/panelsSlice";
 
 const Sidebar = () => {
-  const [activeTab, setActiveTab] = useState<ActiveTab>(ActiveTab.MAP);
-
   const dispatch = useDispatch();
   const devices = useSelector(selectAllDevices());
+  const activeSidebarPanel = useSelector(selectActiveSidebarPanel());
 
   // Logging only, no necessary functionality
   useEffect(() => { console.log(devices); }, [devices]);
@@ -34,6 +29,10 @@ const Sidebar = () => {
     dispatch(createDeviceAction(id));
   };
 
+  const setActivePane = (panel: ActiveSidebarPanel) => {
+    dispatch(panelsSliceActions.setActiveSidebarPanel(panel));
+  }
+
   return (
     <div className="h-screen flex flex-col justify-between shadow-lg">
       <div>
@@ -42,30 +41,30 @@ const Sidebar = () => {
         </div>
         <div className="flex flex-col">
           <SidebarIcon
-            isActive={activeTab == ActiveTab.MAP}
-            setTabActive={() => setActiveTab(ActiveTab.MAP)}
+            isActive={activeSidebarPanel === "map"}
+            onClick={() => setActivePane("map")}
             renderIcon={() => <MagnifyingGlassIcon className="" />}
           />
           <SidebarIcon
-            isActive={activeTab == ActiveTab.CHAT}
-            setTabActive={() => setActiveTab(ActiveTab.CHAT)}
+            isActive={activeSidebarPanel == "chat"}
+            onClick={() => setActivePane("chat")}
             renderIcon={() => <ChatBubbleBottomCenterTextIcon className="" />}
           />
           <SidebarIcon
-            isActive={activeTab == ActiveTab.INFO}
-            setTabActive={() => setActiveTab(ActiveTab.INFO)}
+            isActive={activeSidebarPanel == "info"}
+            onClick={() => setActivePane("info")}
             renderIcon={() => <DocumentTextIcon className="" />}
           />
           <SidebarIcon
-            isActive={activeTab == ActiveTab.NONE}
-            setTabActive={requestDeviceConnection}
+            isActive={activeSidebarPanel == "none"}
+            onClick={requestDeviceConnection}
             renderIcon={() => <LinkIcon className="" />}
           />
         </div>
       </div>
       <SidebarIcon
-        isActive={activeTab == ActiveTab.SETTINGS}
-        setTabActive={() => setActiveTab(ActiveTab.SETTINGS)}
+        isActive={activeSidebarPanel == "settings"}
+        onClick={() => setActivePane("settings")}
         renderIcon={() => <Cog8ToothIcon className="" />}
       />
     </div>

--- a/src/components/Sidebar/SidebarIcon.tsx
+++ b/src/components/Sidebar/SidebarIcon.tsx
@@ -1,23 +1,21 @@
 import React from "react";
 
 export interface ISidebarIconProps {
-  renderIcon: () => JSX.Element;
   isActive: boolean;
-  setTabActive: () => void;
+  renderIcon: () => JSX.Element;
+  onClick: () => void;
 }
 
-const SidebarIcon = (props: ISidebarIconProps) => {
+const SidebarIcon = ({ isActive, renderIcon, onClick }: ISidebarIconProps) => {
   return (
     <button
       type="button"
-      className={`relative hover:bg-blue-50 w-14 h-14 ${props.isActive ? "bg-blue-50" : ""
+      className={`relative hover:bg-blue-50 w-14 h-14 ${isActive ? "bg-blue-50" : ""
         }`}
-      onClick={() => {
-        props.setTabActive();
-      }}
+      onClick={onClick}
     >
-      <div className="flex text-gray-500 m-4">{props.renderIcon()}</div>
-      {props.isActive && (
+      <div className="flex text-gray-500 m-4">{renderIcon()}</div>
+      {isActive && (
         <span className="absolute bg-blue-400 h-full top-0 right-0 w-1" />
       )}
     </button>

--- a/src/features/device/deviceSlice.ts
+++ b/src/features/device/deviceSlice.ts
@@ -64,13 +64,14 @@ export interface IDeviceState {
   activeNode: INode["data"]["num"] | null;
 }
 
-export const initialDeviceState = {
+export const initialDeviceState: IDeviceState = {
   devices: {},
+  activeNode: null,
 };
 
 export const deviceSlice = createSlice({
   name: "devices",
-  initialState: initialDeviceState as IDeviceState,
+  initialState: initialDeviceState,
   reducers: {
     createDevice: (state, action: PayloadAction<number>) => {
       const deviceId = action.payload;

--- a/src/features/panels/panelsSelectors.ts
+++ b/src/features/panels/panelsSelectors.ts
@@ -1,0 +1,4 @@
+import type { RootState } from "@app/store";
+
+export const selectActiveSidebarPanel = () => (state: RootState) =>
+  state.panels.activeSidebarPanel;

--- a/src/features/panels/panelsSlice.ts
+++ b/src/features/panels/panelsSlice.ts
@@ -1,0 +1,27 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export type ActiveSidebarPanel = "map" | "chat" | "info" | "settings" | "none";
+
+export interface IPanelsSliceState {
+  activeSidebarPanel: ActiveSidebarPanel;
+}
+
+export const initialPanelsState: IPanelsSliceState = {
+  activeSidebarPanel: "none",
+};
+
+export const panelsSlice = createSlice({
+  name: "sidebar",
+  initialState: initialPanelsState,
+  reducers: {
+    setActiveSidebarPanel: (
+      state,
+      action: PayloadAction<ActiveSidebarPanel>
+    ) => {
+      state.activeSidebarPanel = action.payload;
+    },
+  },
+});
+
+export const { actions: panelsSliceActions, reducer: panelsReducer } =
+  panelsSlice;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -1,14 +1,20 @@
 import { configureStore } from "@reduxjs/toolkit";
 import createSagaMiddleware from "redux-saga";
+
 import counterSliceReducer from "@features/counter/counterSlice";
 import { deviceReducer } from "@features/device/deviceSlice";
+import { panelsReducer } from "@features/panels/panelsSlice";
 import rootSaga from "@store/saga";
 
 const sagaMiddleware = createSagaMiddleware();
 const middleware = [sagaMiddleware];
 
 export const store = configureStore({
-  reducer: { counter: counterSliceReducer, devices: deviceReducer },
+  reducer: {
+    counter: counterSliceReducer,
+    devices: deviceReducer,
+    panels: panelsReducer,
+  },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({ thunk: false }).concat(middleware),
   devTools: true,


### PR DESCRIPTION
This PR moves the active sidebar panel state into the redux store in a new `panelsSlice` handler. This PR also adds conditional logic in the `MapView` component that allows the rendering of different left-side panels based on which sidebar panel is currently selected.

![image](https://user-images.githubusercontent.com/46639306/200900943-2f197b96-cf5c-4d11-ac4c-34dc6f6e5e9a.png)

Closes #113 