### PR TITLE
Change take_snapshot function to return string

### DIFF
--- a/src-tauri/src/aux_functions/take_snapshot.rs
+++ b/src-tauri/src/aux_functions/take_snapshot.rs
@@ -37,7 +37,7 @@ fn total_distance(lat1: f64, lon1: f64, alt1: f64, lat2: f64, lon2: f64, alt2: f
     (haversine_distance + alt_difference).sqrt()
 }
 
-fn save_relative_ordering(graph: &Graph, file: &mut File) -> Result<(), Box<dyn Error>> {
+fn save_relative_ordering(graph: &Graph, graph_text: &mut String) {
     let mut nodes = graph.get_nodes().clone();
 
     let smallest_longitude_node = nodes.iter().fold(nodes[0].clone(), |acc, node| {
@@ -69,92 +69,90 @@ fn save_relative_ordering(graph: &Graph, file: &mut File) -> Result<(), Box<dyn 
         a_distance.partial_cmp(&b_distance).unwrap()
     });
 
-    let mut ordering: String = "".to_owned();
+    //let mut ordering: String = "".to_owned();
     let mut ordering_counter = 0;
     let order = graph.get_order();
 
-    ordering.push_str(order.to_string().as_str());
-    ordering.push_str("\n");
+    graph_text.push_str(order.to_string().as_str());
+    graph_text.push_str("\n");
 
     for node in nodes {
-        ordering.push_str("O: ");
-        ordering.push_str(&node.name);
-        ordering.push_str(" ");
-        ordering.push_str(ordering_counter.to_string().as_str());
+        graph_text.push_str("O: ");
+        graph_text.push_str(&node.name);
+        graph_text.push_str(" ");
+        graph_text.push_str(ordering_counter.to_string().as_str());
         ordering_counter += 1;
-        ordering.push_str("\n");
+        graph_text.push_str("\n");
     }
 
-    file.write_all(ordering.as_bytes())
-        .expect("Unable to write data");
+    //file.write_all(ordering.as_bytes())
+    //    .expect("Unable to write data");
 
-    Ok(())
+    //Ok(())
 }
 
-/// Saves the graph to a file
+/// Converts a graph to a string and returns it
 ///
 /// # Arguments
 ///
-/// * `graph` - the graph to save
-/// * `file_name` - the file to save the graph to
-///
-/// # Test
-///
-/// ```rust
-/// use graph::graph_ds::Graph;
-/// let mut G = Graph::new();
-/// let u: String = "u".to_string();
-/// let v: String = "v".to_string();
-/// let w: String = "w".to_string();
-///
-/// let mut node_u = Node::new(u.clone());
-/// node_u.latitude = 43.71489;
-/// node_u.longitude = -72.28486;
-/// let _u_idx = G.add_node_from_struct(node_u);
-///
-/// let mut node_v = Node::new(v.clone());
-/// node_v.set_gps(43.71584, -72.28239, 11.23);
-/// let _v_idx = G.add_node_from_struct(node_v);
-///
-/// let mut node_w = Node::new(w.clone());
-/// node_w.set_gps(43.7114, -72.28332, 12.23)
-/// let _w_idx = G.add_node_from_struct(node_w);
-///
-/// G.add_edge(u.clone(), v.clone(), 1 as f64);
-/// G.add_edge(u.clone(), w.clone(), 1 as f64);
-/// G.add_edge(v.clone(), w.clone(), 35 as f64);
-///
-/// let file_name = "test_graph.txt";
-/// save_graph_to_txt_file(&G, file_name).unwrap();
-/// ```
-pub fn save_graph_to_txt_file(graph: &Graph, file_name: &str) -> Result<(), Box<dyn Error>> {
-    let mut file = File::create(file_name)?;
+/// * `graph` - the graph to convert
+pub fn take_snapshot_of_graph(graph: &Graph) -> String {
+    let mut graph_string = "".to_owned();
 
-    save_relative_ordering(graph, &mut file)?;
+    save_relative_ordering(graph, &mut graph_string);
 
-    let mut edges_rep: String = "".to_owned();
+    //let mut edges_rep: String = "".to_owned();
 
     for edge in graph.get_edges() {
-        edges_rep.push_str("E: ");
+        graph_string.push_str("E: ");
         let u_idx = edge.get_u();
         let node_u = graph.get_node(u_idx);
-        edges_rep.push_str(&node_u.name);
-        edges_rep.push_str(" ");
+        graph_string.push_str(&node_u.name);
+        graph_string.push_str(" ");
 
         let b_idx = edge.get_v();
         let node_b = graph.get_node(b_idx);
-        edges_rep.push_str(&node_b.name);
-        edges_rep.push_str(" ");
+        graph_string.push_str(&node_b.name);
+        graph_string.push_str(" ");
 
         let weight = edge.get_weight();
-        edges_rep.push_str(&weight.to_string());
-        edges_rep.push_str("\n");
+        graph_string.push_str(&weight.to_string());
+        graph_string.push_str("\n");
     }
 
-    edges_rep.pop();
+    graph_string.pop();
 
-    file.write_all(edges_rep.as_bytes())
-        .expect("Unable to write data");
+    return graph_string;
+}
 
-    Ok(())
+// Create a unit test for the Graph struct
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_take_snapshot() {
+        // Create a graph
+        let mut G = Graph::new();
+
+        // Create a few nodes and edges and add to graph
+        let u: String = "u".to_string();
+        let v: String = "v".to_string();
+        let w: String = "w".to_string();
+
+        let _u_idx = G.add_node(u.clone());
+        let _v_idx = G.add_node(v.clone());
+        let _w_idx = G.add_node(w.clone());
+
+        G.add_edge(u.clone(), v.clone(), 1 as f64);
+        G.add_edge(u.clone(), w.clone(), 1 as f64);
+        G.add_edge(v.clone(), w.clone(), 35 as f64);
+
+        // Take a snapshot of the graph
+        let snapshot = take_snapshot_of_graph(&G);
+
+        let expected = "3\nO: u 0\nO: v 1\nO: w 2\nE: u v 1\nE: u w 1\nE: v w 35";
+        assert_eq!(snapshot, expected);
+        println!("{}", snapshot);
+    }
 }


### PR DESCRIPTION
This PR just changes the functionality that used to save graph snapshot to a txt file. It now returns the string instead of saving it to be passed into python api.