### PR TITLE
Correctly Add Protobuf Submodule

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,3 @@
 [submodule "src-tauri/protobufs"]
 	path = src-tauri/protobufs
-	url = https://github.com/meshtastic/Meshtastic-protobufs.git
+	url = https://github.com/meshtastic/protobufs


### PR DESCRIPTION
This PR updates the way the [Meshtastic Protobufs](https://github.com/meshtastic/protobufs) repo is added as a submodule into this project to allow for automatic submodule cloning. To test this, checkout this branch and run `pnpm run rust:dev` and ensure this project builds without errors.