### PR TITLE
Refresh Node Timeout Value

### DIFF
--- a/src/components/Map/MapNode.tsx
+++ b/src/components/Map/MapNode.tsx
@@ -45,7 +45,8 @@ const MapNode = ({
   useEffect(() => {
     const intervalId = setInterval(reloadTimeSinceLastMessage, 1000);
     return () => clearInterval(intervalId);
-  }, [reloadTimeSinceLastMessage]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <Marker

--- a/src/components/Map/MapNode.tsx
+++ b/src/components/Map/MapNode.tsx
@@ -1,32 +1,51 @@
-import React from 'react';
-import { Marker } from 'react-map-gl';
+import React, { useCallback, useEffect, useState } from "react";
+import { Marker } from "react-map-gl";
 
-import MapNodeIcon from '@components/Map/MapNodeIcon';
-import type { INode } from '@features/device/deviceSlice';
-import { getTimeSinceLastMessage, getNodeState, getHeadingFromNodeState, getColorClassFromNodeState } from '@utils/nodeUtils';
+import MapNodeIcon from "@components/Map/MapNodeIcon";
+import type { INode } from "@features/device/deviceSlice";
+import {
+  getTimeSinceLastMessage,
+  getNodeState,
+  getHeadingFromNodeState,
+  getColorClassFromNodeState,
+} from "@utils/nodeUtils";
 
 export interface IMapNodeProps {
   node: INode;
   onClick: (nodeId: number | null) => void;
-  size?: 'sm' | 'med' | 'lg'
+  size?: "sm" | "med" | "lg";
   isBase?: boolean;
   isActive?: boolean;
 }
 
-const MapNode = ({ node, onClick, size = 'med', isBase = false, isActive = false }: IMapNodeProps) => {
-  const timeSinceLastMessage = getTimeSinceLastMessage(node);
+const MapNode = ({
+  node,
+  onClick,
+  size = "med",
+  isBase = false,
+  isActive = false,
+}: IMapNodeProps) => {
+  const [timeSinceLastMessage, setTimeSinceLastMessage] = useState(0);
 
   const nodeState = getNodeState(timeSinceLastMessage, isActive);
   const headingPrefix = getHeadingFromNodeState(nodeState, isBase);
 
-  const showMessageTime = nodeState === 'warning' || nodeState === 'error';
   const colorClasses = getColorClassFromNodeState(nodeState);
   const iconRotation = !isBase ? node.data.position?.groundTrack ?? 0 : 0;
 
   const handleNodeClick = (e: mapboxgl.MapboxEvent<MouseEvent>) => {
     e.originalEvent.preventDefault();
     onClick(node.data.num);
-  }
+  };
+
+  const reloadTimeSinceLastMessage = useCallback(() => {
+    setTimeSinceLastMessage(getTimeSinceLastMessage(node));
+  }, [setTimeSinceLastMessage, node]);
+
+  useEffect(() => {
+    const intervalId = setInterval(reloadTimeSinceLastMessage, 1000);
+    return () => clearInterval(intervalId);
+  }, [reloadTimeSinceLastMessage]);
 
   return (
     <Marker
@@ -34,11 +53,25 @@ const MapNode = ({ node, onClick, size = 'med', isBase = false, isActive = false
       longitude={(node.data.position?.longitudeI ?? 0) / 1e7}
       onClick={handleNodeClick}
     >
-      <div className='relative'>
-        <div className="absolute left-2/4 text-center whitespace-nowrap px-2 py-1 default-overlay text-xs" style={{ transform: "translate(-50%, -120%)" }}>
-          {headingPrefix && <span className={`font-bold ${colorClasses.text}`}>{headingPrefix} </span>}
-          <span className={`font-normal ${colorClasses.text}`}>{node.data.user?.longName ?? node.data.num}</span>
-          {showMessageTime && (<span className={`font-normal ${colorClasses.text}`}> ({timeSinceLastMessage} min)</span>)}
+      <div className="relative">
+        <div
+          className="absolute left-2/4 text-center whitespace-nowrap px-2 py-1 default-overlay text-xs"
+          style={{ transform: "translate(-50%, -120%)" }}
+        >
+          {headingPrefix && (
+            <span className={`font-bold ${colorClasses.text}`}>
+              {headingPrefix}{" "}
+            </span>
+          )}
+          <span className={`font-normal ${colorClasses.text}`}>
+            {node.data.user?.longName ?? node.data.num}
+          </span>
+          {(nodeState === "warning" || nodeState === "error") && (
+            <span className={`font-normal ${colorClasses.text}`}>
+              {" "}
+              ({timeSinceLastMessage} min)
+            </span>
+          )}
         </div>
 
         <div style={{ transform: `rotate(${iconRotation}deg)` }}>

--- a/src/components/NodeSearch/NodeSearchResult.tsx
+++ b/src/components/NodeSearch/NodeSearchResult.tsx
@@ -61,7 +61,8 @@ const NodeSearchResult = ({
   useEffect(() => {
     const intervalId = setInterval(reloadTimeSinceLastMessage, 1000);
     return () => clearInterval(intervalId);
-  }, [reloadTimeSinceLastMessage]);
+    // eslint-disable-next-line react-hooks/exhaustive-deps
+  }, []);
 
   return (
     <div className="flex flex-row gap-4">

--- a/src/components/NodeSearch/NodeSearchResult.tsx
+++ b/src/components/NodeSearch/NodeSearchResult.tsx
@@ -1,13 +1,18 @@
-import React from 'react';
-import { ShieldExclamationIcon, SignalIcon, SignalSlashIcon, ViewfinderCircleIcon } from '@heroicons/react/24/outline';
+import React, { useCallback, useEffect, useState } from "react";
+import {
+  ShieldExclamationIcon,
+  SignalIcon,
+  SignalSlashIcon,
+  ViewfinderCircleIcon,
+} from "@heroicons/react/24/outline";
 
-import type { INode } from '@features/device/deviceSlice';
+import type { INode } from "@features/device/deviceSlice";
 import {
   getColorClassFromNodeState,
   getNodeState,
   getTimeSinceLastMessage,
-  NodeState
-} from '@utils/nodeUtils';
+  NodeState,
+} from "@utils/nodeUtils";
 
 export interface INodeSearchResultProps {
   node: INode;
@@ -16,7 +21,7 @@ export interface INodeSearchResultProps {
 }
 
 interface _INodeSearchResultIconProps {
-  nodeState: NodeState
+  nodeState: NodeState;
 }
 
 const _NodeSearchResultIcon = ({ nodeState }: _INodeSearchResultIconProps) => {
@@ -25,20 +30,38 @@ const _NodeSearchResultIcon = ({ nodeState }: _INodeSearchResultIconProps) => {
       return <SignalIcon className="w-6 h-6 mx-0 my-auto text-blue-500" />;
 
     case "warning":
-      return <SignalSlashIcon className="w-6 h-6 mx-0 my-auto text-orange-500" />;
+      return (
+        <SignalSlashIcon className="w-6 h-6 mx-0 my-auto text-orange-500" />
+      );
 
     case "error":
-      return <ShieldExclamationIcon className="w-6 h-6 mx-0 my-auto text-red-500" />;
+      return (
+        <ShieldExclamationIcon className="w-6 h-6 mx-0 my-auto text-red-500" />
+      );
 
     default:
       return <SignalIcon className="w-6 h-6 mx-0 my-auto text-gray-500" />;
   }
-}
+};
 
-const NodeSearchResult = ({ node, isActive, selectNode }: INodeSearchResultProps) => {
-  const timeSinceLastMessage = getTimeSinceLastMessage(node);
+const NodeSearchResult = ({
+  node,
+  isActive,
+  selectNode,
+}: INodeSearchResultProps) => {
+  const [timeSinceLastMessage, setTimeSinceLastMessage] = useState(0);
+
   const nodeState = getNodeState(timeSinceLastMessage, isActive);
   const colorClasses = getColorClassFromNodeState(nodeState);
+
+  const reloadTimeSinceLastMessage = useCallback(() => {
+    setTimeSinceLastMessage(getTimeSinceLastMessage(node));
+  }, [setTimeSinceLastMessage, node]);
+
+  useEffect(() => {
+    const intervalId = setInterval(reloadTimeSinceLastMessage, 1000);
+    return () => clearInterval(intervalId);
+  }, [reloadTimeSinceLastMessage]);
 
   return (
     <div className="flex flex-row gap-4">
@@ -47,7 +70,9 @@ const NodeSearchResult = ({ node, isActive, selectNode }: INodeSearchResultProps
       <div className={`flex-grow ${colorClasses.text}`}>
         <p className="text-lg font-semibold">
           {node.data.user?.longName ?? node.data.num}
-          <span className="text-sm font-normal pl-2">{timeSinceLastMessage} min</span>
+          <span className="text-sm font-normal pl-2">
+            {timeSinceLastMessage} min
+          </span>
         </p>
         {/* <p>{Buffer.from(node.data.user?.macaddr ?? []).toString('hex')}</p> */}
         <p className="text-sm font-light">demo mac address</p>
@@ -57,8 +82,8 @@ const NodeSearchResult = ({ node, isActive, selectNode }: INodeSearchResultProps
         className={`w-6 h-6 mx-0 my-auto ${colorClasses.text} hover:cursor-pointer`}
         onClick={() => selectNode(node.data.num)}
       />
-    </div >
+    </div>
   );
-}
+};
 
 export default NodeSearchResult;


### PR DESCRIPTION
Currently the `timeSinceLastMessage` value cannot trigger rerenders, meaning if no other renders trigger, this value will always stay at 0. This PR adds `setInterval` hooks within the `MapNode` and `NodeSearchResults` components, which will re-render each component every second.

![image](https://user-images.githubusercontent.com/46639306/201501006-502a60c3-3623-4649-b8e3-e3abde3fdb11.png)

Closes #117 