### PR TITLE
Run Algorithms on Live Data

### DIFF
--- a/src-tauri/src/algorithms/stoer_wagner.rs
+++ b/src-tauri/src/algorithms/stoer_wagner.rs
@@ -24,11 +24,10 @@ pub fn st_mincut(g: &mut StoerWagnerGraph) -> Option<Cut> {
         }
         bheap.build_heap();
     }
-
-    let weight = a[a.len() - 1].weight;
     if a.len() < 2 {
         return None;
     }
+    let weight = a[a.len() - 1].weight;
 
     let s = a[a.len() - 1].node.name.clone();
     let t = a[a.len() - 2].node.name.clone();

--- a/src-tauri/src/algorithms/stoer_wagner.rs
+++ b/src-tauri/src/algorithms/stoer_wagner.rs
@@ -143,8 +143,13 @@ mod tests {
         for _ in 0..100 {
             let graph_sw = &mut StoerWagnerGraph::new(g.clone());
             let mincut = stoer_wagner(graph_sw);
-            if mincut.get_weight() == 1.0 {
-                correct_mincut_weight_count += 1;
+            match mincut {
+                Some(cut) => {
+                    if cut.get_weight() == 1.0 {
+                        correct_mincut_weight_count += 1;
+                    }
+                }
+                None => {}
             }
         }
 

--- a/src-tauri/src/algorithms/stoer_wagner.rs
+++ b/src-tauri/src/algorithms/stoer_wagner.rs
@@ -35,17 +35,31 @@ pub fn st_mincut(g: &mut StoerWagnerGraph) -> Option<Cut> {
     return Some(Cut::new(weight, s, t));
 }
 
-pub fn stoer_wagner(graph: &mut StoerWagnerGraph) -> Cut {
+pub fn stoer_wagner(graph: &mut StoerWagnerGraph) -> Option<Cut> {
     if graph.uncontracted.len() == 2 {
-        return graph.get_cut();
+        return Some(graph.get_cut());
     } else {
-        let cut = st_mincut(graph).unwrap();
-        graph.contract_edge(cut.get_a().to_string(), cut.get_b().to_string());
-        let other_cut = stoer_wagner(graph);
-        if cut.get_weight() < other_cut.get_weight() {
-            return cut;
-        } else {
-            return other_cut;
+        let mut min_cut = st_mincut(graph);
+        match min_cut {
+            Some(cut) => {
+                graph.contract_edge(cut.get_a().to_string(), cut.get_b().to_string());
+                let new_cut = stoer_wagner(graph);
+                match new_cut {
+                    Some(new_cut) => {
+                        if new_cut.get_weight() < cut.get_weight() {
+                            return Some(new_cut);
+                        } else {
+                            return Some(cut);
+                        }
+                    }
+                    None => {
+                        return Some(cut);
+                    }
+                }
+            }
+            None => {
+                return None;
+            }
         }
     }
 }

--- a/src-tauri/src/aux_functions/commands.rs
+++ b/src-tauri/src/aux_functions/commands.rs
@@ -42,12 +42,20 @@ pub fn run_stoer_wagner(nodes: Vec<NeighborInfo>) -> String {
     println!("Calculating stoer wagner with input: {:?}", nodes);
     let graph = load_graph(nodes.clone());
     let graph_sw = &mut StoerWagnerGraph::new(graph.clone());
-    let stoer_wagner = stoer_wagner(&mut graph_sw.clone());
-    let output = format!(
-        "Stoer-Wagner: {} {} {}",
-        stoer_wagner.get_a(),
-        stoer_wagner.get_b(),
-        stoer_wagner.get_weight()
-    );
-    output
+    let cut = stoer_wagner(&mut graph_sw.clone());
+    match cut {
+        Some(stoer_wagner) => {
+            let output = format!(
+                "Stoer-Wagner: {} {} {}",
+                stoer_wagner.get_a(),
+                stoer_wagner.get_b(),
+                stoer_wagner.get_weight()
+            );
+            return output;
+        }
+        None => {
+            let output = format!("Stoer-Wagner: No cut found");
+            return output;
+        }
+    }
 }

--- a/src-tauri/src/aux_functions/commands.rs
+++ b/src-tauri/src/aux_functions/commands.rs
@@ -1,0 +1,47 @@
+use crate::algorithms::articulation_point::articulation_point;
+use crate::algorithms::globalmincut::karger_stein_gmincut;
+use crate::algorithms::stoer_wagner::stoer_wagner;
+use crate::aux_data_structures::neighbor_info::{Neighbor, NeighborInfo};
+use crate::aux_data_structures::stoer_wagner_ds::StoerWagnerGraph;
+use crate::aux_functions::graph_init::load_graph;
+use petgraph::graphmap::Nodes;
+use petgraph::stable_graph::NodeIndex;
+
+#[tauri::command]
+pub fn run_articulation_point(nodes: Vec<NeighborInfo>) -> String {
+    // Assemble a vector of nodes and their neighbors
+    println!("{:?}", nodes);
+    let mut graph = load_graph(nodes.clone());
+    let articulation_points = articulation_point(graph.clone());
+    let mut output = String::new();
+    output.push_str("Output: ");
+    for pt in articulation_points {
+        println!("Articulation point: {:?}", pt);
+        output.push_str(&graph.g.node_weight(pt).unwrap().name);
+    }
+    output
+}
+
+#[tauri::command]
+pub fn run_global_mincut(nodes: Vec<NeighborInfo>) -> f64 {
+    let graph = load_graph(nodes.clone());
+    println!("Hit global mincut");
+    let order = graph.get_order();
+    let global_min_cut = karger_stein_gmincut(&graph.clone(), order as i32);
+    global_min_cut
+}
+
+#[tauri::command]
+pub fn run_stoer_wagner(nodes: Vec<NeighborInfo>) -> String {
+    let graph = load_graph(nodes.clone());
+    println!("Hit Stoer-Wagner");
+    let graph_sw = &mut StoerWagnerGraph::new(graph.clone());
+    let stoer_wagner = stoer_wagner(&mut graph_sw.clone());
+    let output = format!(
+        "Stoer-Wagner: {} {} {}",
+        stoer_wagner.get_a(),
+        stoer_wagner.get_b(),
+        stoer_wagner.get_weight()
+    );
+    output
+}

--- a/src-tauri/src/aux_functions/mod.rs
+++ b/src-tauri/src/aux_functions/mod.rs
@@ -1,3 +1,4 @@
+pub(crate) mod commands;
 pub(crate) mod edge_factory;
 pub(crate) mod graph_init;
 pub(crate) mod take_snapshot;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -3,20 +3,11 @@ mod aux_data_structures;
 mod graph;
 // Reference: https://rfdonnelly.github.io/posts/tauri-async-rust-process/
 mod aux_functions;
-use algorithms::articulation_point::articulation_point;
-use algorithms::globalmincut::karger_stein_gmincut;
-use algorithms::stoer_wagner::stoer_wagner;
-use aux_data_structures::neighbor_info::{Neighbor, NeighborInfo};
-use aux_data_structures::stoer_wagner_ds::StoerWagnerGraph;
-use aux_functions::graph_init::load_graph;
-use petgraph::graphmap::Nodes;
-use petgraph::stable_graph::NodeIndex;
-
+use aux_functions::commands::{run_articulation_point, run_global_mincut, run_stoer_wagner};
 use tauri::Manager;
 use tokio::sync::{mpsc, Mutex};
 use tracing::info;
 use tracing_subscriber;
-
 struct AsyncProcInputTx {
     inner: Mutex<mpsc::Sender<String>>,
 }
@@ -86,43 +77,4 @@ async fn async_process_model(
     }
 
     Ok(())
-}
-
-#[tauri::command]
-fn run_articulation_point(nodes: Vec<NeighborInfo>) -> String {
-    // Assemble a vector of nodes and their neighbors
-    println!("{:?}", nodes);
-    let mut graph = load_graph(nodes.clone());
-    let articulation_points = articulation_point(graph.clone());
-    let mut output = String::new();
-    output.push_str("Output: ");
-    for pt in articulation_points {
-        println!("Articulation point: {:?}", pt);
-        output.push_str(&graph.g.node_weight(pt).unwrap().name);
-    }
-    output
-}
-
-#[tauri::command]
-fn run_global_mincut(nodes: Vec<NeighborInfo>) -> f64 {
-    let graph = load_graph(nodes.clone());
-    println!("Hit global mincut");
-    let order = graph.get_order();
-    let global_min_cut = karger_stein_gmincut(&graph.clone(), order as i32);
-    global_min_cut
-}
-
-#[tauri::command]
-fn run_stoer_wagner(nodes: Vec<NeighborInfo>) -> String {
-    let graph = load_graph(nodes.clone());
-    println!("Hit Stoer-Wagner");
-    let graph_sw = &mut StoerWagnerGraph::new(graph.clone());
-    let stoer_wagner = stoer_wagner(&mut graph_sw.clone());
-    let output = format!(
-        "Stoer-Wagner: {} {} {}",
-        stoer_wagner.get_a(),
-        stoer_wagner.get_b(),
-        stoer_wagner.get_weight()
-    );
-    output
 }

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -42,8 +42,9 @@ const Sidebar = () => {
   };
 
   const requestArticulationPoint = () => {
+    const nodeList: INode[] = generateDemoData();
     const nbrInfoList: NeighborInfo[] = generateNeighborInfo(nodes);
-    console.log("Sending test command with neighbors...");
+    console.log("Sending command with input...");
     console.log(nbrInfoList);
     invoke("run_articulation_point", {
       nodes: nbrInfoList,
@@ -55,7 +56,7 @@ const Sidebar = () => {
   };
   const requestGlobalMincut = () => {
     const nodeList: INode[] = generateDemoData();
-    const nbrInfoList: NeighborInfo[] = generateNeighborInfo(nodeList);
+    const nbrInfoList: NeighborInfo[] = generateNeighborInfo(nodes);
     console.log("Sending test command with neighbors...");
     console.log(nbrInfoList);
     invoke("run_global_mincut", {
@@ -68,7 +69,7 @@ const Sidebar = () => {
   };
   const requestStoerWagner = () => {
     const nodeList: INode[] = generateDemoData();
-    const nbrInfoList: NeighborInfo[] = generateNeighborInfo(nodeList);
+    const nbrInfoList: NeighborInfo[] = generateNeighborInfo(nodes);
     console.log("Sending test command with neighbors...");
     console.log(nbrInfoList);
     invoke("run_stoer_wagner", {

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -42,8 +42,7 @@ const Sidebar = () => {
   };
 
   const requestArticulationPoint = () => {
-    const nodeList: INode[] = generateDemoData();
-    const nbrInfoList: NeighborInfo[] = generateNeighborInfo(nodeList);
+    const nbrInfoList: NeighborInfo[] = generateNeighborInfo(nodes);
     console.log("Sending test command with neighbors...");
     console.log(nbrInfoList);
     invoke("run_articulation_point", {


### PR DESCRIPTION
This PR makes the three-line change in the Sidebar to pass actual node data to the backend. 

It also implements corresponding null checks to make sure that the app does not panic if there are no nodes detected. Unit tests are updated accordingly.

As of this PR, we make the assumption that our graph is fully connected, or at least that neighbors are known, by artificially adding them to neighbor lists in `generateNeighborInfo` in `DemoData.tsx`. This is a temporary assumption and can easily be changed.

Testing: 
- tested by running `pnpm run rust:dev` with no nodes