### PR TITLE
[Bugfix] Return Min Cut Correctly

### DIFF
--- a/src-tauri/src/algorithms/stoer_wagner.rs
+++ b/src-tauri/src/algorithms/stoer_wagner.rs
@@ -39,12 +39,12 @@ pub fn stoer_wagner(graph: &mut StoerWagnerGraph) -> Option<Cut> {
     if graph.uncontracted.len() == 2 {
         return Some(graph.get_cut());
     } else {
-        let cut = st_mincut(graph);
-        match cut {
+        let opt_cut = st_mincut(graph);
+        match opt_cut {
             Some(cut) => {
                 graph.contract_edge(cut.get_a().to_string(), cut.get_b().to_string());
-                let other_cut = stoer_wagner(graph);
-                match other_cut {
+                let opt_other_cut = stoer_wagner(graph);
+                match opt_other_cut {
                     Some(other_cut) => {
                         if cut.get_weight() < other_cut.get_weight() {
                             return Some(cut);

--- a/src-tauri/src/algorithms/stoer_wagner.rs
+++ b/src-tauri/src/algorithms/stoer_wagner.rs
@@ -39,21 +39,21 @@ pub fn stoer_wagner(graph: &mut StoerWagnerGraph) -> Option<Cut> {
     if graph.uncontracted.len() == 2 {
         return Some(graph.get_cut());
     } else {
-        let mut min_cut = st_mincut(graph);
-        match min_cut {
+        let cut = st_mincut(graph);
+        match cut {
             Some(cut) => {
                 graph.contract_edge(cut.get_a().to_string(), cut.get_b().to_string());
-                let new_cut = stoer_wagner(graph);
-                match new_cut {
-                    Some(new_cut) => {
-                        if new_cut.get_weight() < cut.get_weight() {
-                            return Some(new_cut);
-                        } else {
+                let other_cut = stoer_wagner(graph);
+                match other_cut {
+                    Some(other_cut) => {
+                        if cut.get_weight() < other_cut.get_weight() {
                             return Some(cut);
+                        } else {
+                            return Some(other_cut);
                         }
                     }
                     None => {
-                        return Some(cut);
+                        return None;
                     }
                 }
             }


### PR DESCRIPTION
Accidentally flipped a conditional and returned the highest weighted cut. Fixes that; no changes to functionality

Closes #140 