### PR TITLE
Fix Windows serial connection bug

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -58,8 +58,10 @@ async fn connect_to_serial_port(
     mesh_device: tauri::State<'_, ActiveMeshDevice>,
     serial_connection: tauri::State<'_, ActiveSerialConnection>,
 ) -> Result<(), String> {
-    let mut connection: SerialConnection = MeshConnection::new();
-    connection.connect(port_name, 115_200).unwrap();
+    let mut connection = SerialConnection::new();
+    connection
+        .connect(port_name, 115_200)
+        .expect("Could not connect to serial port at 115_200 baud");
 
     let mut decoded_listener = connection
         .on_decoded_packet

--- a/src-tauri/src/mesh/serial_connection.rs
+++ b/src-tauri/src/mesh/serial_connection.rs
@@ -308,7 +308,9 @@ impl SerialConnection {
         port_name: impl Into<String>,
         baud_rate: u32,
     ) -> Result<(JoinHandle<()>, JoinHandle<()>, JoinHandle<()>), Box<dyn Error>> {
-        let mut port = serialport::new(port_name.into(), baud_rate).open()?;
+        let mut port = serialport::new(port_name.into(), baud_rate)
+            .timeout(Duration::from_millis(10))
+            .open()?;
 
         let (write_input_tx, write_input_rx) = sync::mpsc::channel::<Vec<u8>>();
         let (read_output_tx, read_output_rx) = sync::mpsc::channel::<Vec<u8>>();

--- a/src/components/Messages/Messages.tsx
+++ b/src/components/Messages/Messages.tsx
@@ -46,7 +46,7 @@ const Messages = () => {
       </div>
 
       <div className="flex flex-1 flex-col rounded-lg w-full h-auto bg-white border-gray-50 drop-shadow justify-top overflow-y-auto">
-        <div className="flex flex-col p-6 overflow-scroll gap-4">
+        <div className="flex flex-col p-6 overflow-auto gap-4">
           {messages.reduce((accum, message) => {
             if (!("text" in message.payload)) return accum;
 


### PR DESCRIPTION
This PR fixes a bug in which users on Windows could not connect to serial ports, getting the message "Access is denied" when attempting to connect. This PR resolves this bug, as well as a visual bug on Windows where the `Messages` view will always display a scrollbar.
