### PR TITLE
Uhuruhashimoto/protobuf conversion

### DIFF
--- a/src-tauri/src/aux_functions/conversion_factors.rs
+++ b/src-tauri/src/aux_functions/conversion_factors.rs
@@ -1,0 +1,8 @@
+// public protobuf conversion factors, used to load graph and mock data. See mesh.proto
+
+/* Lat: 1e-7 conversion from int to floating point degrees; see mesh.proto */
+pub const LAT_CONVERSION_FACTOR: f64 = 1e-7;
+/* Longitude: 1e-7 conversion from int to floating point degrees; see mesh.proto */
+pub const LON_CONVERSION_FACTOR: f64 = 1e-7;
+/* Altitude: in meters above sea level, no conversion needed */
+pub const ALT_CONVERSION_FACTOR: f64 = 1.0;

--- a/src-tauri/src/aux_functions/graph_init.rs
+++ b/src-tauri/src/aux_functions/graph_init.rs
@@ -4,6 +4,26 @@ use crate::aux_data_structures::neighbor_info::{Neighbor, NeighborInfo};
 use crate::graph::graph_ds::Graph;
 use petgraph::graph::NodeIndex;
 
+/* Lat: 1e-7 conversion from int to floating point degrees; see mesh.proto */
+const LAT_CONVERSION_FACTOR: f64 = 1e-7;
+/* Longitude: 1e-7 conversion from int to floating point degrees; see mesh.proto */
+const LON_CONVERSION_FACTOR: f64 = 1e-7;
+/* Altitude: in meters above sea level, no conversion needed */
+const ALT_CONVERSION_FACTOR: f64 = 1.0;
+struct ConversionFactors {
+    pub lat_conversion_factor: f64,
+    pub lon_conversion_factor: f64,
+    pub alt_conversion_factor: f64,
+}
+/*
+* public const of protobuf conversion factors, used to load graph and mock data. See mesh.proto
+*/
+pub const CONVERSION_FACTORS: ConversionFactors = ConversionFactors {
+    lat_conversion_factor: LAT_CONVERSION_FACTOR,
+    lon_conversion_factor: LON_CONVERSION_FACTOR,
+    alt_conversion_factor: ALT_CONVERSION_FACTOR,
+};
+
 /*
 * This function creates a graph from the input data.
 */
@@ -61,10 +81,6 @@ pub fn load_graph(data: Vec<NeighborInfo>) -> Graph {
 
 /*
 * Calculates the distance between two points on a sphere
-*
-* Conversion function:
-* Lat/Long: 1e-7 conversion from int to floating point degrees; see mesh.proto
-* Altitude: in meters above sea level, no conversion needed
 */
 fn calculate_converted_distance(x: f64, y: f64, z: f64, nbr_x: f64, nbr_y: f64, nbr_z: f64) -> f64 {
     let conversion_factor = (10.0 as f64).powi(-7);

--- a/src-tauri/src/aux_functions/graph_init.rs
+++ b/src-tauri/src/aux_functions/graph_init.rs
@@ -65,12 +65,12 @@ pub fn load_graph(data: Vec<NeighborInfo>) -> Graph {
 */
 fn calculate_converted_distance(x: f64, y: f64, z: f64, nbr_x: f64, nbr_y: f64, nbr_z: f64) -> f64 {
     return total_distance(
-        (x as f64) * LAT_CONVERSION_FACTOR,
-        (y as f64) * LON_CONVERSION_FACTOR,
-        (z as f64) * ALT_CONVERSION_FACTOR,
-        (nbr_x as f64) * LAT_CONVERSION_FACTOR,
-        (nbr_y as f64) * LON_CONVERSION_FACTOR,
-        (nbr_z as f64) * ALT_CONVERSION_FACTOR,
+        x * LAT_CONVERSION_FACTOR,
+        y * LON_CONVERSION_FACTOR,
+        z * ALT_CONVERSION_FACTOR,
+        nbr_x * LAT_CONVERSION_FACTOR,
+        nbr_y * LON_CONVERSION_FACTOR,
+        nbr_z * ALT_CONVERSION_FACTOR,
     );
 }
 

--- a/src-tauri/src/aux_functions/graph_init.rs
+++ b/src-tauri/src/aux_functions/graph_init.rs
@@ -1,28 +1,9 @@
 use super::edge_factory::edge_factory;
 use super::take_snapshot::total_distance;
 use crate::aux_data_structures::neighbor_info::{Neighbor, NeighborInfo};
+use crate::aux_functions::conversion_factors::*;
 use crate::graph::graph_ds::Graph;
 use petgraph::graph::NodeIndex;
-
-/* Lat: 1e-7 conversion from int to floating point degrees; see mesh.proto */
-const LAT_CONVERSION_FACTOR: f64 = 1e-7;
-/* Longitude: 1e-7 conversion from int to floating point degrees; see mesh.proto */
-const LON_CONVERSION_FACTOR: f64 = 1e-7;
-/* Altitude: in meters above sea level, no conversion needed */
-const ALT_CONVERSION_FACTOR: f64 = 1.0;
-struct ConversionFactors {
-    pub lat_conversion_factor: f64,
-    pub lon_conversion_factor: f64,
-    pub alt_conversion_factor: f64,
-}
-/*
-* public const of protobuf conversion factors, used to load graph and mock data. See mesh.proto
-*/
-pub const CONVERSION_FACTORS: ConversionFactors = ConversionFactors {
-    lat_conversion_factor: LAT_CONVERSION_FACTOR,
-    lon_conversion_factor: LON_CONVERSION_FACTOR,
-    alt_conversion_factor: ALT_CONVERSION_FACTOR,
-};
 
 /*
 * This function creates a graph from the input data.
@@ -83,14 +64,13 @@ pub fn load_graph(data: Vec<NeighborInfo>) -> Graph {
 * Calculates the distance between two points on a sphere
 */
 fn calculate_converted_distance(x: f64, y: f64, z: f64, nbr_x: f64, nbr_y: f64, nbr_z: f64) -> f64 {
-    let conversion_factor = (10.0 as f64).powi(-7);
     return total_distance(
-        (x as f64) * conversion_factor,
-        (y as f64) * conversion_factor,
-        z as f64,
-        (nbr_x as f64) * conversion_factor,
-        (nbr_y as f64) * conversion_factor,
-        nbr_z as f64,
+        (x as f64) * LAT_CONVERSION_FACTOR,
+        (y as f64) * LON_CONVERSION_FACTOR,
+        (z as f64) * ALT_CONVERSION_FACTOR,
+        (nbr_x as f64) * LAT_CONVERSION_FACTOR,
+        (nbr_y as f64) * LON_CONVERSION_FACTOR,
+        (nbr_z as f64) * ALT_CONVERSION_FACTOR,
     );
 }
 

--- a/src-tauri/src/aux_functions/mod.rs
+++ b/src-tauri/src/aux_functions/mod.rs
@@ -1,4 +1,5 @@
 pub(crate) mod commands;
+pub(crate) mod conversion_factors;
 pub(crate) mod convert_to_graph_from_string;
 pub(crate) mod edge_factory;
 pub(crate) mod get_most_similar;


### PR DESCRIPTION
## Goal
Centralize protobuf conversion constants into one file and use it in graph construction. 

## Implementation
Lat/lng constants are public in `conversion_constants.rs`. We may want to organize them as we add more for different protobuf fields so we don't pollute namespaces more than necessary (for example, structs by category). 

## Testing
unittests pass.