### PR TITLE
Added a function to calculate diffusion centralities

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -78,6 +78,7 @@ dependencies = [
  "async-trait",
  "bytes",
  "defaultdict",
+ "nalgebra",
  "petgraph",
  "prost",
  "prost-build",
@@ -95,6 +96,15 @@ dependencies = [
  "tracing-subscriber",
  "ts-rs",
  "walkdir",
+]
+
+[[package]]
+name = "approx"
+version = "0.5.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "cab112f0a86d568ea0e627cc1d6be74a1e9cd55214684db5561995f6dad897c6"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -1553,6 +1563,15 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "a3e378b66a060d48947b590737b30a1be76706c8dd7b8ba0f2fe3989c68a853f"
 
 [[package]]
+name = "matrixmultiply"
+version = "0.3.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "add85d4dd35074e6fedc608f8c8f513a3548619a9024b751949ef0e8e45a4d84"
+dependencies = [
+ "rawpointer",
+]
+
+[[package]]
 name = "memchr"
 version = "2.5.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -1599,6 +1618,33 @@ name = "multimap"
 version = "0.8.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e5ce46fe64a9d73be07dcbe690a38ce1b293be448fd8ce1e6c1b8062c9f72c6a"
+
+[[package]]
+name = "nalgebra"
+version = "0.32.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "f6515c882ebfddccaa73ead7320ca28036c4bc84c9bcca3cc0cbba8efe89223a"
+dependencies = [
+ "approx",
+ "matrixmultiply",
+ "nalgebra-macros",
+ "num-complex",
+ "num-rational",
+ "num-traits",
+ "simba",
+ "typenum",
+]
+
+[[package]]
+name = "nalgebra-macros"
+version = "0.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d232c68884c0c99810a5a4d333ef7e47689cfd0edc85efc9e54e1e6bf5212766"
+dependencies = [
+ "proc-macro2",
+ "quote",
+ "syn",
+]
 
 [[package]]
 name = "native-tls"
@@ -1677,6 +1723,15 @@ checksum = "77a8165726e8236064dbb45459242600304b42a5ea24ee2948e18e023bf7ba84"
 dependencies = [
  "overload",
  "winapi",
+]
+
+[[package]]
+name = "num-complex"
+version = "0.4.2"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "7ae39348c8bc5fbd7f40c727a9925f03517afd2ab27d46702108b6a7e5414c19"
+dependencies = [
+ "num-traits",
 ]
 
 [[package]]
@@ -2351,6 +2406,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "rawpointer"
+version = "0.2.1"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "60a357793950651c4ed0f3f52338f53b2f809f32d83a07f72909fa13e4c6c1e3"
+
+[[package]]
 name = "redox_syscall"
 version = "0.2.16"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -2471,6 +2532,15 @@ name = "ryu"
 version = "1.0.11"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "4501abdff3ae82a1c1b477a17252eb69cee9e66eb915c1abaa4f44d873df9f09"
+
+[[package]]
+name = "safe_arch"
+version = "0.6.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "794821e4ccb0d9f979512f9c1973480123f9bd62a90d74ab0f9426fcf8f4a529"
+dependencies = [
+ "bytemuck",
+]
 
 [[package]]
 name = "safemem"
@@ -2731,6 +2801,19 @@ source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "e51e73328dc4ac0c7ccbda3a494dfa03df1de2f46018127f60c693f2648455b0"
 dependencies = [
  "libc",
+]
+
+[[package]]
+name = "simba"
+version = "0.8.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "50582927ed6f77e4ac020c057f37a268fc6aebc29225050365aacbb9deeeddc4"
+dependencies = [
+ "approx",
+ "num-complex",
+ "num-traits",
+ "paste",
+ "wide",
 ]
 
 [[package]]
@@ -3691,6 +3774,16 @@ dependencies = [
  "either",
  "libc",
  "once_cell",
+]
+
+[[package]]
+name = "wide"
+version = "0.7.5"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ae41ecad2489a1655c8ef8489444b0b113c0a0c795944a3572a0931cf7d2525c"
+dependencies = [
+ "bytemuck",
+ "safe_arch",
 ]
 
 [[package]]

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -20,6 +20,7 @@ walkdir = "2.3.2"
 [dependencies]
 rand = "0.8.5"
 petgraph = "0.6.2"
+nalgebra = "0.32.1"
 defaultdict = "0.13.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1.0"

--- a/src-tauri/src/algorithms/diffcen.rs
+++ b/src-tauri/src/algorithms/diffcen.rs
@@ -4,6 +4,17 @@ use crate::aux_functions::adj_matrix::convert_to_adj_matrix;
 use crate::graph::graph_ds::Graph;
 use nalgebra::DMatrix;
 
+/// Calculates the diffusion centrality of each node in the graph.
+/// Diffusion centrality is a measure of how much information a node
+/// can diffuse to other nodes in the graph.
+///
+/// # Arguments
+///
+/// * `g` - The graph to calculate diffusion centrality for.
+///
+/// # Returns
+///
+/// * `Option<HashMap<String, HashMap<String, f64>>>` - A hashmap of node ids to a hashmap of node ids to diffusion centrality values.
 pub fn diffusion_centrality(g: &Graph) -> Option<HashMap<String, HashMap<String, f64>>> {
     let (adj_matrix, int_to_node_id) = convert_to_adj_matrix(g);
     let mut node_to_diffcen = HashMap::new();

--- a/src-tauri/src/algorithms/diffcen.rs
+++ b/src-tauri/src/algorithms/diffcen.rs
@@ -15,7 +15,7 @@ use nalgebra::DMatrix;
 /// # Returns
 ///
 /// * `Option<HashMap<String, HashMap<String, f64>>>` - A hashmap of node ids to a hashmap of node ids to diffusion centrality values.
-pub fn diffusion_centrality(g: &Graph) -> Option<HashMap<String, HashMap<String, f64>>> {
+pub fn diffusion_centrality(g: &Graph, T: u32) -> Option<HashMap<String, HashMap<String, f64>>> {
     let (adj_matrix, int_to_node_id) = convert_to_adj_matrix(g);
     let mut node_to_diffcen = HashMap::new();
 
@@ -50,7 +50,7 @@ pub fn diffusion_centrality(g: &Graph) -> Option<HashMap<String, HashMap<String,
 
             let mut H = DMatrix::zeros(g.get_nodes().len(), g.get_nodes().len());
 
-            for t in 1..6 {
+            for t in 1..T + 1 {
                 H += (q * &matrix).pow(t) * &identity_matrix;
             }
 
@@ -100,7 +100,7 @@ mod tests {
         G1.add_edge(u.clone(), w.clone(), 7 as f64);
         G1.add_edge(v.clone(), w.clone(), 35 as f64);
 
-        let diff_cents = diffusion_centrality(&G1);
+        let diff_cents = diffusion_centrality(&G1, 5);
         println!("{:?}", diff_cents);
         assert!(diff_cents.is_some());
     }

--- a/src-tauri/src/algorithms/diffcen.rs
+++ b/src-tauri/src/algorithms/diffcen.rs
@@ -1,0 +1,96 @@
+use std::collections::HashMap;
+
+use crate::aux_functions::adj_matrix::convert_to_adj_matrix;
+use crate::graph::graph_ds::Graph;
+use nalgebra::DMatrix;
+
+pub fn diffusion_centrality(g: &Graph) -> Option<HashMap<String, HashMap<String, f64>>> {
+    let (adj_matrix, int_to_node_id) = convert_to_adj_matrix(g);
+    let mut node_to_diffcen = HashMap::new();
+
+    let flattened_matrix = adj_matrix
+        .iter()
+        .map(|row| row.iter())
+        .flatten()
+        .map(|x| *x)
+        .collect::<Vec<f64>>();
+
+    let matrix =
+        DMatrix::from_row_slice(g.get_nodes().len(), g.get_nodes().len(), &flattened_matrix);
+
+    let schur = matrix.clone().schur();
+
+    let eigenvalues_option = schur.eigenvalues();
+
+    match eigenvalues_option {
+        // If eigenvalues are real, then we can unwrap the eigenvalues
+        Some(eigenvalues) => {
+            let eigenvalues_vec: Vec<f64> = eigenvalues.data.as_vec().clone();
+
+            let largest_eigenvalue = eigenvalues_vec
+                .iter()
+                .max_by(|a, b| a.partial_cmp(b).unwrap())
+                .unwrap_or(&1.0);
+
+            let q = 1.0 / largest_eigenvalue;
+
+            let identity_matrix =
+                DMatrix::<f64>::identity(g.get_nodes().len(), g.get_nodes().len());
+
+            let mut H = DMatrix::zeros(g.get_nodes().len(), g.get_nodes().len());
+
+            for t in 1..6 {
+                H += (q * &matrix).pow(t) * &identity_matrix;
+            }
+
+            for (i, row) in H.row_iter().enumerate() {
+                let mut node_to_diffcen_inner = HashMap::new();
+                for (j, col) in row.iter().enumerate() {
+                    if i == j {
+                        let sum = row.sum();
+                        node_to_diffcen_inner.insert(int_to_node_id.get(&j).unwrap().clone(), sum);
+                        continue;
+                    }
+                    node_to_diffcen_inner
+                        .insert(int_to_node_id.get(&j).unwrap().clone(), *col as f64);
+                }
+                node_to_diffcen.insert(
+                    int_to_node_id.get(&i).unwrap().clone(),
+                    node_to_diffcen_inner,
+                );
+            }
+
+            Some(node_to_diffcen)
+        }
+        // Eigenvalues are complex, can't calculate diffusion centralities
+        None => None,
+    }
+}
+
+// add unit tests
+#[cfg(test)]
+mod tests {
+    use super::*;
+
+    #[test]
+    fn test_diffusion_centrality() {
+        let mut G1 = Graph::new();
+
+        // Create a few nodes and edges and add to graph
+        let u: String = "u".to_string();
+        let v: String = "v".to_string();
+        let w: String = "w".to_string();
+
+        let _u_idx = G1.add_node(u.clone());
+        let _v_idx = G1.add_node(v.clone());
+        let _w_idx = G1.add_node(w.clone());
+
+        G1.add_edge(u.clone(), v.clone(), 1 as f64);
+        G1.add_edge(u.clone(), w.clone(), 7 as f64);
+        G1.add_edge(v.clone(), w.clone(), 35 as f64);
+
+        let diff_cents = diffusion_centrality(&G1);
+        println!("{:?}", diff_cents);
+        assert!(diff_cents.is_some());
+    }
+}

--- a/src-tauri/src/algorithms/diffcen.rs
+++ b/src-tauri/src/algorithms/diffcen.rs
@@ -55,8 +55,13 @@ pub fn diffusion_centrality(g: &Graph, T: u32) -> Option<HashMap<String, HashMap
             }
 
             for (i, row) in H.row_iter().enumerate() {
+                let row_sum = row.sum();
+
+                // divide the row by the sum of the row
+                let row_normalized = row.map(|x| x / row_sum);
+
                 let mut node_to_diffcen_inner = HashMap::new();
-                for (j, col) in row.iter().enumerate() {
+                for (j, col) in row_normalized.iter().enumerate() {
                     if i == j {
                         let sum = row.sum();
                         node_to_diffcen_inner.insert(int_to_node_id.get(&j).unwrap().clone(), sum);
@@ -100,7 +105,7 @@ mod tests {
         G1.add_edge(u.clone(), w.clone(), 7 as f64);
         G1.add_edge(v.clone(), w.clone(), 35 as f64);
 
-        let diff_cents = diffusion_centrality(&G1, 5);
+        let diff_cents = diffusion_centrality(&G1, 1);
         println!("{:?}", diff_cents);
         assert!(diff_cents.is_some());
     }

--- a/src-tauri/src/algorithms/mod.rs
+++ b/src-tauri/src/algorithms/mod.rs
@@ -1,3 +1,4 @@
 pub mod articulation_point;
+pub mod diffcen;
 pub mod globalmincut;
 pub mod stoer_wagner;

--- a/src-tauri/src/aux_functions/adj_matrix.rs
+++ b/src-tauri/src/aux_functions/adj_matrix.rs
@@ -10,16 +10,19 @@ use std::collections::HashMap;
 /// # Returns
 ///
 /// * `Vec<Vec<f64>>` - an adjacency matrix
-pub fn convert_to_adj_matrix(graph: &Graph) -> Vec<Vec<f64>> {
+pub fn convert_to_adj_matrix(graph: &Graph) -> (Vec<Vec<f64>>, HashMap<usize, String>) {
     let mut adj_matrix: Vec<Vec<f64>> = Vec::new();
+
     let nodes = graph.get_nodes();
     let edges = graph.get_edges();
 
     let mut ordering_counter = 0 as usize;
     let mut node_id_to_int = HashMap::new();
+    let mut int_to_node_id = HashMap::new();
 
     for node in nodes.clone() {
         node_id_to_int.insert(node.name.clone(), ordering_counter);
+        int_to_node_id.insert(ordering_counter, node.name.clone());
         ordering_counter += 1;
     }
 
@@ -44,7 +47,7 @@ pub fn convert_to_adj_matrix(graph: &Graph) -> Vec<Vec<f64>> {
         adj_matrix[*v_id][*u_id] = weight;
     }
 
-    return adj_matrix;
+    return (adj_matrix, int_to_node_id);
 }
 
 #[cfg(test)]
@@ -91,7 +94,7 @@ mod tests {
         let b_d = Edge::new(b_idx, d_idx, 0.6);
         G1.add_edge_from_struct(b_d);
 
-        let adj_matrix = convert_to_adj_matrix(&G1);
+        let (adj_matrix, int_to_node_if) = convert_to_adj_matrix(&G1);
 
         // print out the adjacency matrix
         for row in adj_matrix {

--- a/src-tauri/src/aux_functions/adj_matrix.rs
+++ b/src-tauri/src/aux_functions/adj_matrix.rs
@@ -11,7 +11,7 @@ use std::collections::HashMap;
 ///
 /// * `Vec<Vec<f64>>` - an adjacency matrix
 pub fn convert_to_adj_matrix(graph: &Graph) -> (Vec<Vec<f64>>, HashMap<usize, String>) {
-    let mut adj_matrix: Vec<Vec<f64>> = Vec::new();
+    let mut adj_matrix = Vec::new();
 
     let nodes = graph.get_nodes();
     let edges = graph.get_edges();
@@ -20,14 +20,14 @@ pub fn convert_to_adj_matrix(graph: &Graph) -> (Vec<Vec<f64>>, HashMap<usize, St
     let mut node_id_to_int = HashMap::new();
     let mut int_to_node_id = HashMap::new();
 
-    for node in nodes.clone() {
+    for node in &nodes {
         node_id_to_int.insert(node.name.clone(), ordering_counter);
         int_to_node_id.insert(ordering_counter, node.name.clone());
         ordering_counter += 1;
     }
 
     for _ in 0..nodes.len() {
-        let mut row: Vec<f64> = Vec::new();
+        let mut row = Vec::new();
         for _ in 0..nodes.len() {
             row.push(0.0);
         }
@@ -61,10 +61,10 @@ mod tests {
         let mut G1 = Graph::new();
 
         // Create a few nodes and edges and add to graph
-        let a: String = "a".to_string();
-        let b: String = "b".to_string();
-        let c: String = "c".to_string();
-        let d: String = "d".to_string();
+        let a = "a".to_string();
+        let b = "b".to_string();
+        let c = "c".to_string();
+        let d = "d".to_string();
 
         let mut a_node = Node::new(a.clone());
         a_node.set_gps(-72.28486, 43.71489, 1.0);
@@ -96,12 +96,15 @@ mod tests {
 
         let (adj_matrix, int_to_node_if) = convert_to_adj_matrix(&G1);
 
-        // print out the adjacency matrix
-        for row in adj_matrix {
-            for col in row {
-                print!("{} ", col);
-            }
-            println!();
-        }
+        // assert that the adjacency matrix is correct
+        assert_eq!(
+            adj_matrix,
+            vec![
+                vec![0.0, 0.51, 0.39, 0.0],
+                vec![0.51, 0.0, 0.4, 0.6],
+                vec![0.39, 0.4, 0.0, 0.0],
+                vec![0.0, 0.6, 0.0, 0.0]
+            ]
+        );
     }
 }


### PR DESCRIPTION
Closes #202 

This algorithm is a probabilistic simulation of network reliability in T time periods. Specifically, given node a, it calculates the expected number of times a will be able to communicate with the rest of the network. 

It returns a 2D map with the following format:
```txt
{
  “a”: {
	“a”: sum of its scores,
	“b”: E(ab),
	“c”: E(ac),
  },
  “b”: {
	“a”: E(ab),
	“b”: sum of its scores,
	“c”: E(bc),
  },
  “c”: {
	“a”: E(ac),
	“b”: E(bc),
	“c”: sum of its scores,
  }
}
```

The algorithm utilizes matrix powers to simulate paths between all possible nodes and multiplies it with probability q, which is estimated via the maximal eigenvalue v of adjacency matrix where average degree <= v <= max degree. If we consider that in each time unit interval a node tries to communicate with network, then parameter T allows us to simulate this for T time.
