### PR TITLE
Update protobuf genereation to handle proto namespacing change

### DIFF
--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -2,13 +2,13 @@ use prost_build;
 use walkdir::WalkDir;
 
 fn main() -> std::io::Result<()> {
-    println!("cargo:rerun-if-changed=protobufs");
+    let protobufs_dir = "protobufs/meshtastic/";
+    println!("cargo:rerun-if-changed={}", protobufs_dir);
 
     // Allows protobuf compilation without installing the `protoc` binary
     let protoc_path = protoc_bin_vendored::protoc_bin_path().unwrap();
     std::env::set_var("PROTOC", protoc_path);
 
-    let protobufs_dir = "protobufs";
     let mut protos = vec![];
 
     for entry in WalkDir::new(protobufs_dir)

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -2,7 +2,7 @@ use prost_build;
 use walkdir::WalkDir;
 
 fn main() -> std::io::Result<()> {
-    let protobufs_dir = "protobufs/meshtastic/";
+    let protobufs_dir = "protobufs/";
     println!("cargo:rerun-if-changed={}", protobufs_dir);
 
     // Allows protobuf compilation without installing the `protoc` binary

--- a/src-tauri/src/lib.rs
+++ b/src-tauri/src/lib.rs
@@ -1,3 +1,3 @@
 pub mod protobufs {
-    include!(concat!(env!("OUT_DIR"), "/_.rs"));
+    include!(concat!(env!("OUT_DIR"), "/meshtastic.rs"));
 }

--- a/src-tauri/src/mesh/serial_connection.rs
+++ b/src-tauri/src/mesh/serial_connection.rs
@@ -183,8 +183,14 @@ impl MeshConnection for SerialConnection {
             protobufs::from_radio::PayloadVariant::Packet(p) => {
                 device_updated = SerialConnection::handle_mesh_packet(p, device).await?;
             }
+            protobufs::from_radio::PayloadVariant::QueueStatus(_q) => {
+                // println!("Queue status data: {:#?}", q);
+            }
             protobufs::from_radio::PayloadVariant::Rebooted(_r) => {
                 // println!("Rebooted data: {:#?}", r);
+            }
+            protobufs::from_radio::PayloadVariant::XmodemPacket(_p) => {
+                // println!("Xmodem packet: {:#?}", p);
             }
         };
 


### PR DESCRIPTION
This PR updates the build flow to handle namespacing changes introduced in [protobufs/#276](https://github.com/meshtastic/protobufs/pull/276). This PR also adds two additional `match` cases for handling `QueueStatus` and `XmodemPacket` data types.

Closes #208 