### PR TITLE
Connect device user config to settings UI

### DIFF
--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -6,9 +6,7 @@ import { XMarkIcon } from "@heroicons/react/24/solid";
 import { Input } from "@material-tailwind/react";
 
 import { selectActiveNode } from "@features/device/deviceSelectors";
-
 import type { User } from "@bindings/protobufs/User";
-
 import { invoke } from "@tauri-apps/api/tauri";
 
 // Function to convert decimal MAC address to hex

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -29,37 +29,29 @@ const Settings = () => {
 
   // Functions to set device info. Forbidden non-null suppressed, but I checked if a device is connected.
   const [deviceID, setDeviceID] = useState(
-    activeNode ? activeNode.data.user!.id : "No device selected"
+    activeNode?.data.user?.id ?? "No device selected"
   );
   const [deviceName, setDeviceName] = useState(
-    activeNode ? activeNode.data.user!.longName : "No device selected"
+    activeNode?.data.user?.longName ?? "No device selected"
   );
   const [deviceNickname, setDeviceNickname] = useState(
-    activeNode ? activeNode.data.user!.shortName : "No device selected"
+    activeNode?.data.user?.shortName ?? "No device selected"
   );
 
   // MAC, Hardware, and Licensing. Even though they are not displayed when null, the check prevents an error on assignment
   const mac = activeNode
     ? convertMacAddr(activeNode.data.user!.macaddr)
     : "No device selected";
-  const hwModel = activeNode
-    ? activeNode.data.user!.hwModel
-    : "No device selected";
-  const isLicensed = activeNode
-    ? activeNode.data.user!.isLicensed
-    : "No device selected";
+  const hwModel = activeNode?.data.user?.hwModel ?? "No device selected";
+  const isLicensed = activeNode?.data.user?.isLicensed ?? "No device selected";
 
   // Submits the form. Triggered by pressing the save button
   const handleSubmit: FormEventHandler = (e) => {
-    e.preventDefault();
     if (activeNode) {
       const updatedUser: User = {
-        id: deviceID,
+        ...activeNode.data.user!,
         longName: deviceName,
         shortName: deviceNickname,
-        macaddr: activeNode.data.user!.macaddr,
-        hwModel: activeNode.data.user!.hwModel,
-        isLicensed: activeNode.data.user!.isLicensed,
       };
 
       invoke("update_device_user", { user: updatedUser }).catch((e) => {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -57,9 +57,9 @@ const Settings = () => {
         id: deviceID,
         longName: deviceName,
         shortName: deviceNickname,
-        macaddr: activeNode ? activeNode.data.user!.macaddr : [],
-        hwModel: activeNode ? activeNode.data.user!.hwModel : 0,
-        isLicensed: activeNode ? activeNode.data.user!.isLicensed : false,
+        macaddr: activeNode.data.user!.macaddr,
+        hwModel: activeNode.data.user!.hwModel,
+        isLicensed: activeNode.data.user!.isLicensed,
       };
 
       invoke("update_device_user", { user: updatedUser }).catch((e) => {

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -51,7 +51,7 @@ const Settings = () => {
 
   // Submits the form. Triggered by pressing the save button
   const handleSubmit: FormEventHandler = (e) => {
-    // e.preventDefault();
+    e.preventDefault();
     if (activeNode) {
       const updatedUser: User = {
         id: deviceID,
@@ -59,7 +59,7 @@ const Settings = () => {
         shortName: deviceNickname,
         macaddr: activeNode ? activeNode.data.user!.macaddr : [],
         hwModel: activeNode ? activeNode.data.user!.hwModel : 0,
-        isLicensed: activeNode ? activeNode.data.user!.isLicensed : true,
+        isLicensed: activeNode ? activeNode.data.user!.isLicensed : false,
       };
 
       invoke("update_device_user", { user: updatedUser }).catch((e) => {
@@ -160,6 +160,7 @@ const Settings = () => {
               <button
                 className="border-black border-1 bg-gray-300 px-[6%] py-[2%] text-xl rounded-md hover:bg-gray-400 hover:border-2"
                 type="submit"
+                disabled={!activeNode}
               >
                 Save
               </button>

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -7,6 +7,10 @@ import { Input } from "@material-tailwind/react";
 
 import { selectActiveNode } from "@features/device/deviceSelectors";
 
+import type { User } from "@bindings/protobufs/User";
+
+import { invoke } from "@tauri-apps/api/tauri";
+
 // Function to convert decimal MAC address to hex
 function convertMacAddr(macAddr: number[]) {
   let result = macAddr[0].toString(16);
@@ -49,7 +53,23 @@ const Settings = () => {
 
   // Submits the form. Triggered by pressing the save button
   const handleSubmit: FormEventHandler = (e) => {
-    e.preventDefault();
+    // e.preventDefault();
+    if (activeNode) {
+      const updatedUser: User = {
+        id: deviceID,
+        longName: deviceName,
+        shortName: deviceNickname,
+        macaddr: activeNode ? activeNode.data.user!.macaddr : [],
+        hwModel: activeNode ? activeNode.data.user!.hwModel : 0,
+        isLicensed: activeNode ? activeNode.data.user!.isLicensed : true,
+      };
+
+      invoke("update_device_user", { user: updatedUser }).catch((e) => {
+        console.error(e);
+      });
+    } else {
+      console.log("No active node selected");
+    }
   };
 
   // Render the popup.
@@ -75,7 +95,7 @@ const Settings = () => {
           </div>
         </div>
         <div className="text-sm flex justify-center">
-          Note: This is just the UI, and is not currently connected to backend
+          Note: App will be reloaded on save
         </div>
         {/* Make a form where we put the options */}
         <div className="overflow-y-scroll h-4/5 mt-2">
@@ -138,7 +158,6 @@ const Settings = () => {
             ) : (
               <div></div>
             )}
-            {/* Meshtastic Web Client has two more options - MAC Address and Hardware type. Since both are not changeable, we will not make the UI for these. */}
             <div className="flex justify-center pt-[6%] pb-[3%]">
               <button
                 className="border-black border-1 bg-gray-300 px-[6%] py-[2%] text-xl rounded-md hover:bg-gray-400 hover:border-2"

--- a/src/components/Settings/Settings.tsx
+++ b/src/components/Settings/Settings.tsx
@@ -1,5 +1,5 @@
 import React, { useState, FormEventHandler } from "react";
-import { useSelector } from "react-redux";
+import { useSelector, useDispatch } from "react-redux";
 import { useNavigate } from "react-router-dom";
 
 import { XMarkIcon } from "@heroicons/react/24/solid";
@@ -7,7 +7,7 @@ import { Input } from "@material-tailwind/react";
 
 import { selectActiveNode } from "@features/device/deviceSelectors";
 import type { User } from "@bindings/protobufs/User";
-import { invoke } from "@tauri-apps/api/tauri";
+import { requestUpdateUser } from "@features/device/deviceActions";
 
 // Function to convert decimal MAC address to hex
 function convertMacAddr(macAddr: number[]) {
@@ -45,8 +45,11 @@ const Settings = () => {
   const hwModel = activeNode?.data.user?.hwModel ?? "No device selected";
   const isLicensed = activeNode?.data.user?.isLicensed ?? "No device selected";
 
+  const dispatch = useDispatch();
+
   // Submits the form. Triggered by pressing the save button
   const handleSubmit: FormEventHandler = (e) => {
+    // e.preventDefault();
     if (activeNode) {
       const updatedUser: User = {
         ...activeNode.data.user!,
@@ -54,9 +57,7 @@ const Settings = () => {
         shortName: deviceNickname,
       };
 
-      invoke("update_device_user", { user: updatedUser }).catch((e) => {
-        console.error(e);
-      });
+      dispatch(requestUpdateUser({ user: updatedUser }));
     } else {
       console.log("No active node selected");
     }

--- a/src/features/device/deviceActions.ts
+++ b/src/features/device/deviceActions.ts
@@ -1,4 +1,5 @@
 import { createAction } from "@reduxjs/toolkit";
+import type { User } from "@bindings/protobufs/User";
 
 export const requestAvailablePorts = createAction(
   "@device/request-available-ports"
@@ -14,4 +15,8 @@ export const requestDisconnectFromDevice = createAction(
 
 export const requestSendMessage = createAction<{ text: string; channel: 0 }>(
   "@device/request-send-message"
+);
+
+export const requestUpdateUser = createAction<{ user: User }>(
+  "@device/update-device-user"
 );

--- a/src/features/device/deviceSagas.ts
+++ b/src/features/device/deviceSagas.ts
@@ -11,6 +11,7 @@ import {
   requestConnectToDevice,
   requestDisconnectFromDevice,
   requestSendMessage,
+  requestUpdateUser,
 } from "@features/device/deviceActions";
 import { deviceSliceActions } from "@features/device/deviceSlice";
 
@@ -73,11 +74,22 @@ function* sendMessageWorker(action: ReturnType<typeof requestSendMessage>) {
   }
 }
 
+function* updateUserConfig(action: ReturnType<typeof requestUpdateUser>) {
+  try {
+    yield call(invoke, "update_device_user", {
+      user: action.payload.user,
+    });
+  } catch (error) {
+    yield put({ type: "GENERAL_ERROR", payload: error });
+  }
+}
+
 export function* devicesSaga() {
   yield all([
     takeEvery(requestAvailablePorts.type, getAvailableSerialPortsWorker),
     takeEvery(requestConnectToDevice.type, connectToDeviceWorker),
     takeEvery(requestDisconnectFromDevice.type, disconnectFromDeviceWorker),
     takeEvery(requestSendMessage.type, sendMessageWorker),
+    takeEvery(requestUpdateUser.type, updateUserConfig),
   ]);
 }


### PR DESCRIPTION
PR that connects rust backend to current version of settings UI. Allows for changing the `longname` and `shortname` of an active node connected through serial, according to user input in the settings pane. App restarts upon saving.



Will likely be refactored upon implementation of updated UI.
![implement_changes](https://user-images.githubusercontent.com/57198797/214233926-370e07e3-9ff8-42c1-959b-3e7770d66a3e.gif)



Closes #164