### PR TITLE
Add request (command) state management

### DIFF
--- a/src/features/device/deviceConnectionHandlerSagas.ts
+++ b/src/features/device/deviceConnectionHandlerSagas.ts
@@ -31,8 +31,6 @@ export function* handleDeviceUpdateChannel(channel: DeviceUpdateChannel) {
     while (true) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const meshDevice: MeshDevice = yield take(channel);
-      console.log("updated device", meshDevice);
-
       yield put(deviceSliceActions.setDevice(meshDevice));
     }
   } catch (error) {

--- a/src/features/device/deviceSagas.ts
+++ b/src/features/device/deviceSagas.ts
@@ -29,7 +29,7 @@ function* getAvailableSerialPortsWorker(
   action: ReturnType<typeof requestAvailablePorts>
 ) {
   try {
-    yield put(requestSliceActions.setActionPending({ type: action.type }));
+    yield put(requestSliceActions.setRequestPending({ type: action.type }));
 
     const serialPorts = (yield call(
       invoke,
@@ -37,10 +37,10 @@ function* getAvailableSerialPortsWorker(
     )) as string[];
 
     yield put(deviceSliceActions.setAvailableSerialPorts(serialPorts));
-    yield put(requestSliceActions.setActionSuccessful({ type: action.type }));
+    yield put(requestSliceActions.setRequestSuccessful({ type: action.type }));
   } catch (error) {
     yield put(
-      requestSliceActions.setActionFailed({
+      requestSliceActions.setRequestFailed({
         type: action.type,
         message: (error as Error).message,
       })
@@ -52,7 +52,7 @@ function* connectToDeviceWorker(
   action: ReturnType<typeof requestConnectToDevice>
 ) {
   try {
-    yield put(requestSliceActions.setActionPending({ type: action.type }));
+    yield put(requestSliceActions.setRequestPending({ type: action.type }));
 
     yield call(disconnectFromDeviceWorker);
     yield call(invoke, "connect_to_serial_port", { portName: action.payload });
@@ -61,10 +61,10 @@ function* connectToDeviceWorker(
     yield put(requestSendMessage({ channel: 0, text: "Device Initialized" }));
     yield call(subscribeAll);
 
-    yield put(requestSliceActions.setActionSuccessful({ type: action.type }));
+    yield put(requestSliceActions.setRequestSuccessful({ type: action.type }));
   } catch (error) {
     yield put(
-      requestSliceActions.setActionFailed({
+      requestSliceActions.setRequestFailed({
         type: action.type,
         message: (error as Error).message,
       })
@@ -85,17 +85,17 @@ function* disconnectFromDeviceWorker() {
 
 function* sendMessageWorker(action: ReturnType<typeof requestSendMessage>) {
   try {
-    yield put(requestSliceActions.setActionPending({ type: action.type }));
+    yield put(requestSliceActions.setRequestPending({ type: action.type }));
 
     yield call(invoke, "send_text", {
       channel: action.payload.channel,
       text: action.payload.text,
     });
 
-    yield put(requestSliceActions.setActionSuccessful({ type: action.type }));
+    yield put(requestSliceActions.setRequestSuccessful({ type: action.type }));
   } catch (error) {
     yield put(
-      requestSliceActions.setActionFailed({
+      requestSliceActions.setRequestFailed({
         type: action.type,
         message: (error as Error).message,
       })
@@ -105,16 +105,16 @@ function* sendMessageWorker(action: ReturnType<typeof requestSendMessage>) {
 
 function* updateUserConfig(action: ReturnType<typeof requestUpdateUser>) {
   try {
-    yield put(requestSliceActions.setActionPending({ type: action.type }));
+    yield put(requestSliceActions.setRequestPending({ type: action.type }));
 
     yield call(invoke, "update_device_user", {
       user: action.payload.user,
     });
 
-    yield put(requestSliceActions.setActionSuccessful({ type: action.type }));
+    yield put(requestSliceActions.setRequestSuccessful({ type: action.type }));
   } catch (error) {
     yield put(
-      requestSliceActions.setActionFailed({
+      requestSliceActions.setRequestFailed({
         type: action.type,
         message: (error as Error).message,
       })

--- a/src/features/device/deviceSagas.ts
+++ b/src/features/device/deviceSagas.ts
@@ -56,12 +56,13 @@ function* connectToDeviceWorker(
 
     yield call(disconnectFromDeviceWorker);
     yield call(invoke, "connect_to_serial_port", { portName: action.payload });
-
     yield put(deviceSliceActions.setActiveSerialPort(action.payload));
-    yield put(requestSendMessage({ channel: 0, text: "Device Initialized" }));
-    yield call(subscribeAll);
 
     yield put(requestSliceActions.setRequestSuccessful({ name: action.type }));
+
+    yield put(requestSendMessage({ channel: 0, text: "Device Initialized" }));
+
+    yield call(subscribeAll);
   } catch (error) {
     yield put(
       requestSliceActions.setRequestFailed({

--- a/src/features/device/deviceSagas.ts
+++ b/src/features/device/deviceSagas.ts
@@ -29,7 +29,7 @@ function* getAvailableSerialPortsWorker(
   action: ReturnType<typeof requestAvailablePorts>
 ) {
   try {
-    yield put(requestSliceActions.setRequestPending({ type: action.type }));
+    yield put(requestSliceActions.setRequestPending({ name: action.type }));
 
     const serialPorts = (yield call(
       invoke,
@@ -37,11 +37,11 @@ function* getAvailableSerialPortsWorker(
     )) as string[];
 
     yield put(deviceSliceActions.setAvailableSerialPorts(serialPorts));
-    yield put(requestSliceActions.setRequestSuccessful({ type: action.type }));
+    yield put(requestSliceActions.setRequestSuccessful({ name: action.type }));
   } catch (error) {
     yield put(
       requestSliceActions.setRequestFailed({
-        type: action.type,
+        name: action.type,
         message: (error as Error).message,
       })
     );
@@ -52,7 +52,7 @@ function* connectToDeviceWorker(
   action: ReturnType<typeof requestConnectToDevice>
 ) {
   try {
-    yield put(requestSliceActions.setRequestPending({ type: action.type }));
+    yield put(requestSliceActions.setRequestPending({ name: action.type }));
 
     yield call(disconnectFromDeviceWorker);
     yield call(invoke, "connect_to_serial_port", { portName: action.payload });
@@ -61,11 +61,11 @@ function* connectToDeviceWorker(
     yield put(requestSendMessage({ channel: 0, text: "Device Initialized" }));
     yield call(subscribeAll);
 
-    yield put(requestSliceActions.setRequestSuccessful({ type: action.type }));
+    yield put(requestSliceActions.setRequestSuccessful({ name: action.type }));
   } catch (error) {
     yield put(
       requestSliceActions.setRequestFailed({
-        type: action.type,
+        name: action.type,
         message: (error as Error).message,
       })
     );
@@ -85,18 +85,18 @@ function* disconnectFromDeviceWorker() {
 
 function* sendMessageWorker(action: ReturnType<typeof requestSendMessage>) {
   try {
-    yield put(requestSliceActions.setRequestPending({ type: action.type }));
+    yield put(requestSliceActions.setRequestPending({ name: action.type }));
 
     yield call(invoke, "send_text", {
       channel: action.payload.channel,
       text: action.payload.text,
     });
 
-    yield put(requestSliceActions.setRequestSuccessful({ type: action.type }));
+    yield put(requestSliceActions.setRequestSuccessful({ name: action.type }));
   } catch (error) {
     yield put(
       requestSliceActions.setRequestFailed({
-        type: action.type,
+        name: action.type,
         message: (error as Error).message,
       })
     );
@@ -105,17 +105,17 @@ function* sendMessageWorker(action: ReturnType<typeof requestSendMessage>) {
 
 function* updateUserConfig(action: ReturnType<typeof requestUpdateUser>) {
   try {
-    yield put(requestSliceActions.setRequestPending({ type: action.type }));
+    yield put(requestSliceActions.setRequestPending({ name: action.type }));
 
     yield call(invoke, "update_device_user", {
       user: action.payload.user,
     });
 
-    yield put(requestSliceActions.setRequestSuccessful({ type: action.type }));
+    yield put(requestSliceActions.setRequestSuccessful({ name: action.type }));
   } catch (error) {
     yield put(
       requestSliceActions.setRequestFailed({
-        type: action.type,
+        name: action.type,
         message: (error as Error).message,
       })
     );

--- a/src/features/requests/requestReducer.ts
+++ b/src/features/requests/requestReducer.ts
@@ -16,16 +16,16 @@ export const requestSlice = createSlice({
   name: "request",
   initialState: InitialRequestState,
   reducers: {
-    setActionIdle: (state, action: PayloadAction<{ type: string }>) => {
+    setRequestIdle: (state, action: PayloadAction<{ type: string }>) => {
       state.status[action.payload.type] = { status: "IDLE" };
     },
-    setActionPending: (state, action: PayloadAction<{ type: string }>) => {
+    setRequestPending: (state, action: PayloadAction<{ type: string }>) => {
       state.status[action.payload.type] = { status: "PENDING" };
     },
-    setActionSuccessful: (state, action: PayloadAction<{ type: string }>) => {
+    setRequestSuccessful: (state, action: PayloadAction<{ type: string }>) => {
       state.status[action.payload.type] = { status: "SUCCESSFUL" };
     },
-    setActionFailed: (
+    setRequestFailed: (
       state,
       action: PayloadAction<{ type: string; message: string }>
     ) => {
@@ -34,7 +34,7 @@ export const requestSlice = createSlice({
         message: action.payload.message,
       };
     },
-    clearActionState: (state, action: PayloadAction<{ type: string }>) => {
+    clearRequestState: (state, action: PayloadAction<{ type: string }>) => {
       delete state.status[action.payload.type];
     },
   },

--- a/src/features/requests/requestReducer.ts
+++ b/src/features/requests/requestReducer.ts
@@ -16,35 +16,26 @@ export const requestSlice = createSlice({
   name: "request",
   initialState: InitialRequestState,
   reducers: {
-    setActionIdle: (state, action: PayloadAction<{ actionName: string }>) => {
-      state.status[action.payload.actionName] = { status: "IDLE" };
+    setActionIdle: (state, action: PayloadAction<{ type: string }>) => {
+      state.status[action.payload.type] = { status: "IDLE" };
     },
-    setActionPending: (
-      state,
-      action: PayloadAction<{ actionName: string }>
-    ) => {
-      state.status[action.payload.actionName] = { status: "PENDING" };
+    setActionPending: (state, action: PayloadAction<{ type: string }>) => {
+      state.status[action.payload.type] = { status: "PENDING" };
     },
-    setActionSuccessful: (
-      state,
-      action: PayloadAction<{ actionName: string }>
-    ) => {
-      state.status[action.payload.actionName] = { status: "SUCCESSFUL" };
+    setActionSuccessful: (state, action: PayloadAction<{ type: string }>) => {
+      state.status[action.payload.type] = { status: "SUCCESSFUL" };
     },
     setActionFailed: (
       state,
-      action: PayloadAction<{ actionName: string; errorMessage: string }>
+      action: PayloadAction<{ type: string; message: string }>
     ) => {
-      state.status[action.payload.errorMessage] = {
+      state.status[action.payload.message] = {
         status: "FAILED",
-        message: action.payload.errorMessage,
+        message: action.payload.message,
       };
     },
-    clearActionState: (
-      state,
-      action: PayloadAction<{ actionName: string }>
-    ) => {
-      delete state.status[action.payload.actionName];
+    clearActionState: (state, action: PayloadAction<{ type: string }>) => {
+      delete state.status[action.payload.type];
     },
   },
 });

--- a/src/features/requests/requestReducer.ts
+++ b/src/features/requests/requestReducer.ts
@@ -16,26 +16,26 @@ export const requestSlice = createSlice({
   name: "request",
   initialState: InitialRequestState,
   reducers: {
-    setRequestIdle: (state, action: PayloadAction<{ type: string }>) => {
-      state.status[action.payload.type] = { status: "IDLE" };
+    setRequestIdle: (state, action: PayloadAction<{ name: string }>) => {
+      state.status[action.payload.name] = { status: "IDLE" };
     },
-    setRequestPending: (state, action: PayloadAction<{ type: string }>) => {
-      state.status[action.payload.type] = { status: "PENDING" };
+    setRequestPending: (state, action: PayloadAction<{ name: string }>) => {
+      state.status[action.payload.name] = { status: "PENDING" };
     },
-    setRequestSuccessful: (state, action: PayloadAction<{ type: string }>) => {
-      state.status[action.payload.type] = { status: "SUCCESSFUL" };
+    setRequestSuccessful: (state, action: PayloadAction<{ name: string }>) => {
+      state.status[action.payload.name] = { status: "SUCCESSFUL" };
     },
     setRequestFailed: (
       state,
-      action: PayloadAction<{ type: string; message: string }>
+      action: PayloadAction<{ name: string; message: string }>
     ) => {
       state.status[action.payload.message] = {
         status: "FAILED",
         message: action.payload.message,
       };
     },
-    clearRequestState: (state, action: PayloadAction<{ type: string }>) => {
-      delete state.status[action.payload.type];
+    clearRequestState: (state, action: PayloadAction<{ name: string }>) => {
+      delete state.status[action.payload.name];
     },
   },
 });

--- a/src/features/requests/requestReducer.ts
+++ b/src/features/requests/requestReducer.ts
@@ -1,0 +1,53 @@
+import { createSlice, PayloadAction } from "@reduxjs/toolkit";
+
+export type IRequestState =
+  | { status: "IDLE" }
+  | { status: "PENDING" }
+  | { status: "SUCCESSFUL" }
+  | { status: "FAILED"; message: string };
+
+export interface IRequestReducerState {
+  status: Record<string, IRequestState>;
+}
+
+const InitialRequestState: IRequestReducerState = { status: {} };
+
+export const requestSlice = createSlice({
+  name: "request",
+  initialState: InitialRequestState,
+  reducers: {
+    setActionIdle: (state, action: PayloadAction<{ actionName: string }>) => {
+      state.status[action.payload.actionName] = { status: "IDLE" };
+    },
+    setActionPending: (
+      state,
+      action: PayloadAction<{ actionName: string }>
+    ) => {
+      state.status[action.payload.actionName] = { status: "PENDING" };
+    },
+    setActionSuccessful: (
+      state,
+      action: PayloadAction<{ actionName: string }>
+    ) => {
+      state.status[action.payload.actionName] = { status: "SUCCESSFUL" };
+    },
+    setActionFailed: (
+      state,
+      action: PayloadAction<{ actionName: string; errorMessage: string }>
+    ) => {
+      state.status[action.payload.errorMessage] = {
+        status: "FAILED",
+        message: action.payload.errorMessage,
+      };
+    },
+    clearActionState: (
+      state,
+      action: PayloadAction<{ actionName: string }>
+    ) => {
+      delete state.status[action.payload.actionName];
+    },
+  },
+});
+
+export const { actions: requestSliceActions, reducer: requestReducer } =
+  requestSlice;

--- a/src/features/requests/requestSelectors.ts
+++ b/src/features/requests/requestSelectors.ts
@@ -1,0 +1,7 @@
+import type { RootState } from "@app/store";
+import type { IRequestState } from "./requestReducer";
+
+export const selectRequestStateByName =
+  (name: string) =>
+  (state: RootState): IRequestState | null =>
+    state.requests.status?.[name] ?? null;

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -3,6 +3,7 @@ import createSagaMiddleware from "redux-saga";
 import { logger } from "redux-logger";
 
 import { deviceReducer } from "@features/device/deviceSlice";
+import { requestReducer } from "@features/requests/requestReducer";
 import rootSaga from "@store/saga";
 
 const sagaMiddleware = createSagaMiddleware();
@@ -11,6 +12,7 @@ const middleware = [sagaMiddleware, logger];
 export const store = configureStore({
   reducer: {
     devices: deviceReducer,
+    request: requestReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({ thunk: false }).concat(middleware),

--- a/src/store/index.ts
+++ b/src/store/index.ts
@@ -12,7 +12,7 @@ const middleware = [sagaMiddleware, logger];
 export const store = configureStore({
   reducer: {
     devices: deviceReducer,
-    request: requestReducer,
+    requests: requestReducer,
   },
   middleware: (getDefaultMiddleware) =>
     getDefaultMiddleware({ thunk: false }).concat(middleware),


### PR DESCRIPTION
This PR adds a new `request` slice which allows the application to track the state of a given request by a `string` name. In our application we are using this functionality to track the status of commands, but this functionality can be integrated anywhere you can dispatch redux actions. We currently support the following four request states, which are mapped from the `name` of the request:

```typescript
export type IRequestState =
  | { status: "IDLE" }
  | { status: "PENDING" }
  | { status: "SUCCESSFUL" }
  | { status: "FAILED"; message: string };
```

These can be attached to a worker as shown below (`deviceSagas.ts`):

```typescript
function* sendMessageWorker(action: ReturnType<typeof requestSendMessage>) {
  try {
    yield put(requestSliceActions.setRequestPending({ name: action.type }));

    yield call(invoke, "send_text", {
      channel: action.payload.channel,
      text: action.payload.text,
    });

    yield put(requestSliceActions.setRequestSuccessful({ name: action.type }));
  } catch (error) {
    yield put(
      requestSliceActions.setRequestFailed({
        name: action.type,
        message: (error as Error).message,
      })
    );
  }
}
```

Closes #230 