### PR TITLE
Update backend error types

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -90,6 +90,7 @@ dependencies = [
  "serialport",
  "tauri",
  "tauri-build",
+ "thiserror",
  "time",
  "tokio",
  "tracing",
@@ -3230,18 +3231,18 @@ checksum = "8eaa81235c7058867fa8c0e7314f33dcce9c215f535d1913822a2b3f5e289f3c"
 
 [[package]]
 name = "thiserror"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "10deb33631e3c9018b9baf9dcbbc4f737320d2b576bac10f6aefa048fa407e3e"
+checksum = "6a9cd18aa97d5c45c6603caea1da6628790b37f7a34b6ca89522331c5180fed0"
 dependencies = [
  "thiserror-impl",
 ]
 
 [[package]]
 name = "thiserror-impl"
-version = "1.0.37"
+version = "1.0.38"
 source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "982d17546b47146b28f7c22e3d08465f6b8903d0ea13c1660d9d84a6e7adcdbb"
+checksum = "1fb327af4685e4d03fa8cbcf1716380da910eeb2bb8be417e7f9fd3fb164f36f"
 dependencies = [
  "proc-macro2",
  "quote",

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -35,6 +35,7 @@ bytes = "1.2.1"
 async-trait = "0.1.60"
 time = { version = "0.3.17", features = ["macros", "serde"] }
 ts-rs = "6.2.1"
+thiserror = "1.0.38"
 
 [features]
 # by default Tauri runs in production mode

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -59,7 +59,7 @@ async fn connect_to_serial_port(
 
     connection
         .connect(port_name, 115_200)
-        .expect("Could not connect to serial port at 115_200 baud");
+        .map_err(|e| e.to_string())?;
 
     connection
         .configure(new_device.config_id)

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -6,6 +6,7 @@ mod mesh;
 
 use app::protobufs;
 use mesh::serial_connection::{MeshConnection, SerialConnection};
+use serde::{Deserialize, Serialize};
 use std::sync::Arc;
 use tauri::{async_runtime, Manager};
 use tracing_subscriber;
@@ -16,6 +17,18 @@ struct ActiveSerialConnection {
 
 struct ActiveMeshDevice {
     inner: Arc<async_runtime::Mutex<Option<mesh::device::MeshDevice>>>,
+}
+
+#[derive(Clone, Debug, Default, Serialize, Deserialize, thiserror::Error)]
+#[serde(rename_all = "camelCase")]
+struct CommandError {
+    message: String,
+}
+
+impl std::fmt::Display for CommandError {
+    fn fmt(&self, f: &mut std::fmt::Formatter<'_>) -> std::fmt::Result {
+        write!(f, "CommandError: \"{}\"", self.message)
+    }
 }
 
 fn main() {
@@ -43,8 +56,10 @@ fn main() {
 }
 
 #[tauri::command]
-fn get_all_serial_ports() -> Result<Vec<String>, String> {
-    SerialConnection::get_available_ports()
+fn get_all_serial_ports() -> Result<Vec<String>, CommandError> {
+    SerialConnection::get_available_ports().map_err(|e| CommandError {
+        message: e.to_string(),
+    })
 }
 
 #[tauri::command]
@@ -53,20 +68,29 @@ async fn connect_to_serial_port(
     app_handle: tauri::AppHandle,
     mesh_device: tauri::State<'_, ActiveMeshDevice>,
     serial_connection: tauri::State<'_, ActiveSerialConnection>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     let mut connection = SerialConnection::new();
     let new_device = mesh::device::MeshDevice::new();
 
     connection
         .connect(port_name, 115_200)
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?;
 
-    connection.configure(new_device.config_id)?;
+    connection
+        .configure(new_device.config_id)
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?;
 
     let mut decoded_listener = connection
         .on_decoded_packet
         .as_ref()
-        .ok_or("Decoded packet listener not open")?
+        .ok_or("Decoded packet listener not open")
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?
         .resubscribe();
 
     let handle = app_handle.app_handle().clone();
@@ -128,7 +152,7 @@ async fn connect_to_serial_port(
 async fn disconnect_from_serial_port(
     mesh_device: tauri::State<'_, ActiveMeshDevice>,
     serial_connection: tauri::State<'_, ActiveSerialConnection>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     {
         let mut state_connection = serial_connection.inner.lock().await;
         *state_connection = None;
@@ -156,19 +180,23 @@ async fn send_text(
     app_handle: tauri::AppHandle,
     mesh_device: tauri::State<'_, ActiveMeshDevice>,
     serial_connection: tauri::State<'_, ActiveSerialConnection>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     let mut serial_guard = serial_connection.inner.lock().await;
     let mut device_guard = mesh_device.inner.lock().await;
 
     let connection = serial_guard
         .as_mut()
         .ok_or("Connection not initialized")
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?;
 
     let device = device_guard
         .as_mut()
         .ok_or("Device not connected")
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?;
 
     device
         .send_text(
@@ -178,9 +206,13 @@ async fn send_text(
             true,
             channel,
         )
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?;
 
-    dispatch_updated_device(app_handle, device.clone()).map_err(|e| e.to_string())?;
+    dispatch_updated_device(app_handle, device.clone()).map_err(|e| CommandError {
+        message: e.to_string(),
+    })?;
 
     Ok(())
 }
@@ -190,23 +222,29 @@ async fn update_device_config(
     config: protobufs::Config,
     mesh_device: tauri::State<'_, ActiveMeshDevice>,
     serial_connection: tauri::State<'_, ActiveSerialConnection>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     let mut serial_guard = serial_connection.inner.lock().await;
     let mut device_guard = mesh_device.inner.lock().await;
 
     let connection = serial_guard
         .as_mut()
         .ok_or("Connection not initialized")
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?;
 
     let device = device_guard
         .as_mut()
         .ok_or("Device not connected")
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?;
 
     device
         .update_device_config(connection, config)
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?;
 
     Ok(())
 }
@@ -216,23 +254,29 @@ async fn update_device_user(
     user: protobufs::User,
     mesh_device: tauri::State<'_, ActiveMeshDevice>,
     serial_connection: tauri::State<'_, ActiveSerialConnection>,
-) -> Result<(), String> {
+) -> Result<(), CommandError> {
     let mut serial_guard = serial_connection.inner.lock().await;
     let mut device_guard = mesh_device.inner.lock().await;
 
     let connection = serial_guard
         .as_mut()
         .ok_or("Connection not initialized")
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?;
 
     let device = device_guard
         .as_mut()
         .ok_or("Device not connected")
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?;
 
     device
         .update_device_user(connection, user)
-        .map_err(|e| e.to_string())?;
+        .map_err(|e| CommandError {
+            message: e.to_string(),
+        })?;
 
     Ok(())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -61,9 +61,7 @@ async fn connect_to_serial_port(
         .connect(port_name, 115_200)
         .map_err(|e| e.to_string())?;
 
-    connection
-        .configure(new_device.config_id)
-        .expect("Could not configure serial device");
+    connection.configure(new_device.config_id)?;
 
     let mut decoded_listener = connection
         .on_decoded_packet

--- a/src-tauri/src/mesh/device/connection.rs
+++ b/src-tauri/src/mesh/device/connection.rs
@@ -4,7 +4,6 @@ use super::helpers::{generate_rand_id, get_current_time_u32};
 use super::MeshDevice;
 use app::protobufs;
 use prost::Message;
-use std::error::Error;
 
 impl MeshDevice {
     pub fn send_text(
@@ -14,7 +13,7 @@ impl MeshDevice {
         destination: PacketDestination,
         want_ack: bool,
         channel: u32,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), String> {
         let byte_data = text.clone().into_bytes();
 
         self.send_packet(
@@ -37,7 +36,7 @@ impl MeshDevice {
         &mut self,
         connection: &mut SerialConnection,
         config: protobufs::Config,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), String> {
         let config_packet = protobufs::AdminMessage {
             payload_variant: Some(protobufs::admin_message::PayloadVariant::SetConfig(config)),
         };
@@ -64,7 +63,7 @@ impl MeshDevice {
         &mut self,
         connection: &mut SerialConnection,
         user: protobufs::User,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), String> {
         let user_packet = protobufs::AdminMessage {
             payload_variant: Some(protobufs::admin_message::PayloadVariant::SetOwner(user)),
         };
@@ -99,7 +98,7 @@ impl MeshDevice {
         echo_response: bool,
         reply_id: Option<u32>,
         emoji: Option<u32>,
-    ) -> Result<(), Box<dyn Error>> {
+    ) -> Result<(), String> {
         // let own_node_id: u32 = self.my_node_info.as_ref().unwrap().my_node_num;
         let own_node_id: u32 = self.my_node_info.my_node_num;
 
@@ -145,7 +144,10 @@ impl MeshDevice {
         };
 
         let mut packet_buf: Vec<u8> = vec![];
-        to_radio.encode::<Vec<u8>>(&mut packet_buf)?;
+        to_radio
+            .encode::<Vec<u8>>(&mut packet_buf)
+            .map_err(|e| e.to_string())?;
+
         connection.send_raw(packet_buf)?;
 
         Ok(())

--- a/src-tauri/src/mesh/device/state.rs
+++ b/src-tauri/src/mesh/device/state.rs
@@ -134,7 +134,7 @@ impl MeshDevice {
                 .config
                 .index
                 .try_into()
-                .expect("channel id out of u32 range"),
+                .expect("Channel id out of u32 range"),
             channel,
         );
     }

--- a/src/components/Messaging/ChannelListElement.tsx
+++ b/src/components/Messaging/ChannelListElement.tsx
@@ -14,7 +14,6 @@ const ChannelListElement = ({
   isSelected,
 }: IChannelListElementProps) => {
   const lastMessage = channel.messages.at(-1) ?? null;
-  console.log(lastMessage);
   const timeLastMessageReceived: string = lastMessage
     ? new Intl.DateTimeFormat("en-us", {
         hour: "numeric",

--- a/src/components/Onboard/SerialPortOption.tsx
+++ b/src/components/Onboard/SerialPortOption.tsx
@@ -69,10 +69,9 @@ const SerialPortOption = ({
               </h1>
             </div>
             <h1 className="pl-6 pr-2 ml-4 text-sm leading-5 font-light text-red-600 mt-0.5">
-              Could not connect to serial port on {name}, failed with error
-              &quot;
-              {connectionState.message}
-              &quot;
+              Failed to connect with error:
+              <br />
+              <i>{connectionState.message}</i>
             </h1>
           </div>
         </div>

--- a/src/components/pages/SerialConnectPage.tsx
+++ b/src/components/pages/SerialConnectPage.tsx
@@ -13,7 +13,10 @@ import {
 } from "@features/device/deviceActions";
 import { selectAvailablePorts } from "@features/device/deviceSelectors";
 import { selectRequestStateByName } from "@features/requests/requestSelectors";
-import type { IRequestState } from "@features/requests/requestReducer";
+import {
+  IRequestState,
+  requestSliceActions,
+} from "@features/requests/requestReducer";
 
 import "@components/SplashScreen/SplashScreen.css";
 
@@ -33,6 +36,15 @@ const SerialConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
 
   const requestPorts = () => {
     dispatch(requestAvailablePorts());
+  };
+
+  const refreshPorts = () => {
+    dispatch(
+      requestSliceActions.clearRequestState({
+        name: requestConnectToDevice.type,
+      })
+    );
+    requestPorts();
   };
 
   const handlePortSelected = (portName: string) => {
@@ -135,7 +147,7 @@ const SerialConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
         <button
           type="button"
           className="flex flex-row justify-center align-middle gap-4 mt-5"
-          onClick={() => requestPorts()}
+          onClick={() => refreshPorts()}
         >
           <ArrowPathIcon className="text-gray-400 w-6 h-6 hover:cursor-pointer" />
           <p className="my-auto text-gray-500">Refresh ports</p>

--- a/src/features/device/deviceSagas.ts
+++ b/src/features/device/deviceSagas.ts
@@ -42,7 +42,7 @@ function* getAvailableSerialPortsWorker(
     yield put(
       requestSliceActions.setRequestFailed({
         name: action.type,
-        message: (error as Error).message,
+        message: error as string,
       })
     );
   }
@@ -65,7 +65,7 @@ function* connectToDeviceWorker(
     yield put(
       requestSliceActions.setRequestFailed({
         name: action.type,
-        message: (error as Error).message,
+        message: error as string,
       })
     );
   }
@@ -96,7 +96,7 @@ function* sendMessageWorker(action: ReturnType<typeof requestSendMessage>) {
     yield put(
       requestSliceActions.setRequestFailed({
         name: action.type,
-        message: (error as Error).message,
+        message: error as string,
       })
     );
   }
@@ -115,7 +115,7 @@ function* updateUserConfig(action: ReturnType<typeof requestUpdateUser>) {
     yield put(
       requestSliceActions.setRequestFailed({
         name: action.type,
-        message: (error as Error).message,
+        message: error as string,
       })
     );
   }

--- a/src/features/device/deviceSagas.ts
+++ b/src/features/device/deviceSagas.ts
@@ -15,6 +15,7 @@ import {
 } from "@features/device/deviceActions";
 import { deviceSliceActions } from "@features/device/deviceSlice";
 import { requestSliceActions } from "@features/requests/requestReducer";
+import type { CommandError } from "@utils/errors";
 
 function* subscribeAll() {
   // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
@@ -42,7 +43,7 @@ function* getAvailableSerialPortsWorker(
     yield put(
       requestSliceActions.setRequestFailed({
         name: action.type,
-        message: error as string,
+        message: (error as CommandError).message,
       })
     );
   }
@@ -65,7 +66,7 @@ function* connectToDeviceWorker(
     yield put(
       requestSliceActions.setRequestFailed({
         name: action.type,
-        message: error as string,
+        message: (error as CommandError).message,
       })
     );
   }
@@ -96,7 +97,7 @@ function* sendMessageWorker(action: ReturnType<typeof requestSendMessage>) {
     yield put(
       requestSliceActions.setRequestFailed({
         name: action.type,
-        message: error as string,
+        message: (error as CommandError).message,
       })
     );
   }
@@ -115,7 +116,7 @@ function* updateUserConfig(action: ReturnType<typeof requestUpdateUser>) {
     yield put(
       requestSliceActions.setRequestFailed({
         name: action.type,
-        message: error as string,
+        message: (error as CommandError).message,
       })
     );
   }

--- a/src/features/requests/requestReducer.ts
+++ b/src/features/requests/requestReducer.ts
@@ -29,7 +29,7 @@ export const requestSlice = createSlice({
       state,
       action: PayloadAction<{ name: string; message: string }>
     ) => {
-      state.status[action.payload.message] = {
+      state.status[action.payload.name] = {
         status: "FAILED",
         message: action.payload.message,
       };

--- a/src/utils/errors.ts
+++ b/src/utils/errors.ts
@@ -1,0 +1,3 @@
+export interface CommandError {
+  message: string;
+}


### PR DESCRIPTION
This PR updates the current way the backend handles Rust errors from returning a `Result<OK_TYPE, Box<dyn Error>>` to returning a `Result<OK_TYPE, String>`. This will ensure that the error can be kept on the stack instead of the heap ([link](https://doc.rust-lang.org/rust-by-example/std/box.html)), and makes the error returns more intuitive via the `map_err` method.

This PR also updates the Tauri [commands](https://tauri.app/it/v1/guides/features/command/) to return `Result<OK_TYPE, CommandError>`, where the new `CommandError` struct is defined as follows:

```rust
struct CommandError {
    message: String,
}
```

This struct was designed to follow the structure of the JS [Error](https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Error) shape, specifically the `error.message` field.

Closes #267 
Closes #272 