### PR TITLE
Added non-functional options for radio, plugin, and channel config pages

### DIFF
--- a/src/components/config/ConfigLayout.tsx
+++ b/src/components/config/ConfigLayout.tsx
@@ -27,7 +27,7 @@ const ConfigLayout = ({
           <NavigationBacktrace className="my-auto mr-auto" levels={backtrace} />
         </div>
 
-        <div className="flex flex-col flex-1 px-9 py-6">
+        <div className="flex flex-col flex-1 px-9 py-6 overflow-y-auto">
           <div className="flex flex-row justify-between align-middle mb-6">
             <h1 className="text-4xl leading-10 font-semibold text-gray-700">
               {title}

--- a/src/components/config/ConfigOption.tsx
+++ b/src/components/config/ConfigOption.tsx
@@ -1,0 +1,42 @@
+import React from "react";
+
+export interface IConfigOptionProps {
+  title: string;
+  subtitle: string;
+  isActive: boolean;
+  onClick: () => void;
+}
+
+const ConfigOption = ({
+  title,
+  subtitle,
+  isActive,
+  onClick,
+}: IConfigOptionProps) => {
+  if (isActive)
+    return (
+      <button
+        type="button"
+        onClick={onClick}
+        className="flex flex-row justify-between items-baseline px-3 py-4 bg-gray-700 rounded-lg"
+      >
+        <p className="text-sm font-semibold text-gray-100 text-left">{title}</p>
+        <p className="text-xs font-normal text-gray-200 text-right">
+          {subtitle}
+        </p>
+      </button>
+    );
+
+  return (
+    <button
+      type="button"
+      onClick={onClick}
+      className="flex flex-row justify-between items-baseline px-3 py-4 bg-white rounded-lg"
+    >
+      <p className="text-sm font-semibold text-gray-600 text-left">{title}</p>
+      <p className="text-xs font-normal text-gray-500 text-right">{subtitle}</p>
+    </button>
+  );
+};
+
+export default ConfigOption;

--- a/src/components/pages/config/ChannelConfigPage.tsx
+++ b/src/components/pages/config/ChannelConfigPage.tsx
@@ -1,9 +1,17 @@
-import React from "react";
+import React, { useState } from "react";
+import { useSelector } from "react-redux";
 import { QuestionMarkCircleIcon } from "@heroicons/react/24/outline";
 
 import ConfigLayout from "@components/config/ConfigLayout";
+import ConfigOption from "@components/config/ConfigOption";
+
+import { selectDeviceChannels } from "@features/device/deviceSelectors";
+import { getChannelName } from "@utils/messaging";
 
 const ChannelConfigPage = () => {
+  const channels = useSelector(selectDeviceChannels());
+  const [activeChannel, setActiveChannel] = useState<number | null>(null);
+
   return (
     <div className="flex-1">
       <ConfigLayout
@@ -15,12 +23,29 @@ const ChannelConfigPage = () => {
             "Channel configuration title icon onClick not implemented"
           )
         }
-        renderOptions={() => []}
+        renderOptions={() =>
+          channels
+            .filter((c) => c.config.role !== 0) // * ignore DISABLED role
+            .map((c) => (
+              <ConfigOption
+                key={c.config.index}
+                title={getChannelName(c)}
+                subtitle="0 unsaved changes"
+                isActive={activeChannel === c.config.index}
+                onClick={() =>
+                  setActiveChannel(
+                    activeChannel !== c.config.index ? c.config.index : null
+                  )
+                }
+              />
+            ))
+        }
       >
         <div className="flex flex-col justify-center align-middle w-full h-full bg-gray-100">
           <p className="m-auto text-base font-normal text-gray-700">
-            {/* No channel selected */}
-            Feature not complete
+            {activeChannel != null
+              ? `Channel ${activeChannel} selected`
+              : "No channel selected"}
           </p>
         </div>
       </ConfigLayout>

--- a/src/components/pages/config/PluginConfigPage.tsx
+++ b/src/components/pages/config/PluginConfigPage.tsx
@@ -1,9 +1,26 @@
-import React from "react";
+import React, { useState } from "react";
 import { QuestionMarkCircleIcon } from "@heroicons/react/24/outline";
 
 import ConfigLayout from "@components/config/ConfigLayout";
+import ConfigOption from "@components/config/ConfigOption";
+
+export const PluginConfigOptions: { name: string; hash: string }[] = [
+  { name: "Audio Configuration", hash: "audio" },
+  { name: "Canned Message Configuration", hash: "canned_message" },
+  {
+    name: "External Notification Configuration",
+    hash: "external_notification",
+  },
+  { name: "MQTT Configuration", hash: "mqtt" },
+  { name: "Range Test Configuration", hash: "range_test" },
+  { name: "Serial Module Configuration", hash: "serial_module" },
+  { name: "Telemetry Configuration", hash: "telemetry" },
+  { name: "Traceroute Configuration", hash: "traceroute" },
+];
 
 const PluginConfigPage = () => {
+  const [activeOption, setActiveOption] = useState<string | null>(null);
+
   return (
     <div className="flex-1">
       <ConfigLayout
@@ -15,12 +32,25 @@ const PluginConfigPage = () => {
             "Plugin configuration title icon onClick not implemented"
           )
         }
-        renderOptions={() => []}
+        renderOptions={() =>
+          PluginConfigOptions.map(({ name, hash }) => (
+            <ConfigOption
+              key={hash}
+              title={name}
+              subtitle="0 unsaved changes"
+              isActive={activeOption === hash}
+              onClick={() =>
+                setActiveOption(activeOption !== hash ? hash : null)
+              }
+            />
+          ))
+        }
       >
         <div className="flex flex-col justify-center align-middle w-full h-full bg-gray-100">
           <p className="m-auto text-base font-normal text-gray-700">
-            {/* No category selected */}
-            Feature not complete
+            {activeOption
+              ? `Option "${activeOption}" selected`
+              : "No option selected"}
           </p>
         </div>
       </ConfigLayout>

--- a/src/components/pages/config/RadioConfigPage.tsx
+++ b/src/components/pages/config/RadioConfigPage.tsx
@@ -1,9 +1,22 @@
-import React from "react";
+import React, { useState } from "react";
 import { QuestionMarkCircleIcon } from "@heroicons/react/24/outline";
 
 import ConfigLayout from "@components/config/ConfigLayout";
+import ConfigOption from "@components/config/ConfigOption";
+
+export const RadioConfigOptions: { name: string; hash: string }[] = [
+  { name: "User Configuration", hash: "user" },
+  { name: "Device Configuration", hash: "device" },
+  { name: "Power Configuration", hash: "power" },
+  { name: "Network Configuration", hash: "network" },
+  { name: "Display Configuration", hash: "display" },
+  { name: "LoRa Configuration", hash: "lora" },
+  { name: "Bluetooth Configuration", hash: "bluetooth" },
+];
 
 const RadioConfigPage = () => {
+  const [activeOption, setActiveOption] = useState<string | null>(null);
+
   return (
     <div className="flex-1">
       <ConfigLayout
@@ -13,12 +26,25 @@ const RadioConfigPage = () => {
         onTitleIconClick={() =>
           console.warn("Radio configuration title icon onClick not implemented")
         }
-        renderOptions={() => []}
+        renderOptions={() =>
+          RadioConfigOptions.map(({ name, hash }) => (
+            <ConfigOption
+              key={hash}
+              title={name}
+              subtitle="0 unsaved changes"
+              isActive={activeOption === hash}
+              onClick={() =>
+                setActiveOption(activeOption !== hash ? hash : null)
+              }
+            />
+          ))
+        }
       >
         <div className="flex flex-col justify-center align-middle w-full h-full bg-gray-100">
           <p className="m-auto text-base font-normal text-gray-700">
-            {/* No category selected */}
-            Feature not complete
+            {activeOption
+              ? `Option "${activeOption}" selected`
+              : "No option selected"}
           </p>
         </div>
       </ConfigLayout>


### PR DESCRIPTION
This PR adds non-functional config options to the radio, plugin, and channel config pages. While the channel options are generated based on the channels on the connected radio, the radio and plugin configs are hardcoded.

![Screenshot_20230213_110615](https://user-images.githubusercontent.com/46639306/218510279-a81d6f57-2bf3-4d11-a62f-4b70667d02dc.png)

![Screenshot_20230213_110620](https://user-images.githubusercontent.com/46639306/218510278-5e3761ba-1807-4666-9ee8-496b6cedaaf8.png)

![Screenshot_20230213_110626](https://user-images.githubusercontent.com/46639306/218510275-62dbdbac-b29a-431b-b0a9-6221e5e17eaf.png)

Closes #275 