### PR TITLE
Fix sidebar scroll on windows

### DIFF
--- a/src/components/Onboard/SerialPortOption.tsx
+++ b/src/components/Onboard/SerialPortOption.tsx
@@ -23,7 +23,7 @@ const SerialPortOption = ({
     case "IDLE":
       return (
         <button type="button" onClick={() => onClick(name)}>
-          <div className={`flex justify-center`}>
+          <div className="flex justify-center select-none">
             <div className="flex justify-left border rounded-lg border-gray-400 pl-4 pt-5 pb-5 pr-4 w-6/12 hover:bg-gray-50 hover:border-gray-500 hover:shadow-lg hover:cursor-pointer">
               <RadioIcon className="text-gray-500 w-6 h-6" />
               <h1 className="ml-4 text-base leading-6 font-normal text-gray-600 mt-0.5">
@@ -36,7 +36,7 @@ const SerialPortOption = ({
 
     case "PENDING":
       return (
-        <div className="flex justify-center">
+        <div className="flex justify-center select-none">
           <div className="flex justify-left border rounded-lg bg-gray-50 border-gray-500 pl-4 pt-5 pb-5 pr-4 w-6/12 hover:cursor-wait">
             <EllipsisHorizontalCircleIcon className="text-gray-500 w-6 h-6" />
             <h1 className="ml-4 text-base leading-6 font-normal text-gray-600 mt-0.5">
@@ -48,7 +48,7 @@ const SerialPortOption = ({
 
     case "SUCCESSFUL":
       return (
-        <div className={`flex justify-center`}>
+        <div className="flex justify-center select-none">
           <div className="flex justify-left border rounded-lg border-green-500 bg-green-50 pl-4 pt-5 pb-5 pr-4 w-6/12 ">
             <CheckCircleIcon className="text-green-600 w-6 h-6" />
             <h1 className="ml-4 text-base leading-6 font-normal text-green-600 mt-0.5">
@@ -60,7 +60,7 @@ const SerialPortOption = ({
 
     case "FAILED":
       return (
-        <div className="flex justify-center">
+        <div className="flex justify-center select-none">
           <div className=" border rounded-lg border-red-500 bg-red-50 pl-4 pt-5 pb-5 pr-4 w-6/12 ">
             <div className="flex flex-row">
               <XCircleIcon className="text-red-600 w-6 h-6" />
@@ -80,7 +80,7 @@ const SerialPortOption = ({
     default:
       return (
         <div>
-          <div className={`flex justify-center`}>
+          <div className="flex justify-center select-none">
             <div className="flex justify-left border rounded-lg border-gray-400 pl-4 pt-3 pb-3 pr-4 w-6/12 hover:bg-gray-50 hover:border-gray-500 hover:shadow-lg hover:cursor-pointer">
               <XCircleIcon className="text-gray-500 w-6 h-6" />
               <h1 className="ml-4 text-base leading-6 font-normal text-gray-600 mt-0.5">

--- a/src/components/Sidebar/Sidebar.css
+++ b/src/components/Sidebar/Sidebar.css
@@ -7,5 +7,5 @@
 }
 
 .sidebar-background-color-transition {
-  transition: background-color 90ms ease-in-out;
+  transition: background-color 180ms ease-in-out;
 }

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -30,7 +30,7 @@ const Sidebar = () => {
 
   return (
     <div
-      className={`sidebar-width-transition flex flex-col h-screen box-content shadow-lg overflow-y-auto no-scroll border-r border-gray-100 overflow-x-hidden ${isSidebarExpanded ? "w-[300px] text-gray-500" : "w-20 text-white"
+      className={`sidebar-width-transition flex flex-col h-screen box-content shadow-lg overflow-y-auto hide-scrollbar border-r border-gray-100 overflow-x-hidden ${isSidebarExpanded ? "w-[300px] text-gray-500" : "w-20 text-white"
         }`}
     >
       <SidebarLogo isSidebarExpanded={isSidebarExpanded} />

--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -30,9 +30,8 @@ const Sidebar = () => {
 
   return (
     <div
-      className={`sidebar-width-transition flex flex-col h-screen box-content shadow-lg overflow-y-auto border-r border-gray-100 overflow-x-hidden ${
-        isSidebarExpanded ? "w-[300px] text-gray-500" : "w-20 text-white"
-      }`}
+      className={`sidebar-width-transition flex flex-col h-screen box-content shadow-lg overflow-y-auto no-scroll border-r border-gray-100 overflow-x-hidden ${isSidebarExpanded ? "w-[300px] text-gray-500" : "w-20 text-white"
+        }`}
     >
       <SidebarLogo isSidebarExpanded={isSidebarExpanded} />
 

--- a/src/index.css
+++ b/src/index.css
@@ -31,3 +31,14 @@ body {
 .default-overlay.no-shadow {
   @apply shadow-none;
 }
+
+/* Hide scrollbar for Chrome, Safari and Opera */
+.no-scroll::-webkit-scrollbar {
+  display: none;
+}
+
+/* Hide scrollbar for IE, Edge and Firefox */
+.no-scroll {
+  -ms-overflow-style: none; /* IE and Edge */
+  scrollbar-width: none; /* Firefox */
+}

--- a/src/index.css
+++ b/src/index.css
@@ -33,12 +33,12 @@ body {
 }
 
 /* Hide scrollbar for Chrome, Safari and Opera */
-.no-scroll::-webkit-scrollbar {
+.hide-scrollbar::-webkit-scrollbar {
   display: none;
 }
 
 /* Hide scrollbar for IE, Edge and Firefox */
-.no-scroll {
+.hide-scrollbar {
   -ms-overflow-style: none; /* IE and Edge */
   scrollbar-width: none; /* Firefox */
 }


### PR DESCRIPTION
Windows will place a scrollbar on any element that overflows, which takes up space within the layout. This PR adds a new `hide-scrollbar` class, which when placed on an element will hide any scrollbars on that element while maintaining scroll functionality.

![image](https://user-images.githubusercontent.com/46639306/219231156-7d45d401-43a4-46eb-b0f7-f78eca204ad4.png)
