### PR TITLE
bug fix: sidebar size change

### DIFF
--- a/src/components/Sidebar/Sidebar.tsx
+++ b/src/components/Sidebar/Sidebar.tsx
@@ -30,8 +30,9 @@ const Sidebar = () => {
 
   return (
     <div
-      className={`sidebar-width-transition flex flex-col h-screen box-content shadow-lg overflow-y-auto hide-scrollbar border-r border-gray-100 overflow-x-hidden ${isSidebarExpanded ? "w-[300px] text-gray-500" : "w-20 text-white"
-        }`}
+      className={`shrink-0 sidebar-width-transition flex flex-col h-screen box-content shadow-lg overflow-y-auto hide-scrollbar border-r border-gray-100 overflow-x-hidden ${
+        isSidebarExpanded ? "w-[300px] text-gray-500" : "w-20 text-white"
+      }`}
     >
       <SidebarLogo isSidebarExpanded={isSidebarExpanded} />
 


### PR DESCRIPTION
Sidebar shrank when on tabs that had w:full. Comparison below:

Before:
![sidebar shrink prob](https://user-images.githubusercontent.com/57198797/219492067-89a29340-9106-4ebf-ba2f-f31bdf33bd57.gif)


After:
![sidebar shrink fix](https://user-images.githubusercontent.com/57198797/219492095-fbfa918e-7041-4490-bc14-a34b7ac3c345.gif)

