### PR TITLE
Reset app on device disconnect

### DIFF
--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -84,7 +84,7 @@ async fn connect_to_serial_port(
     let mut connection = SerialConnection::new();
     let new_device = mesh::device::MeshDevice::new();
 
-    connection.connect(port_name, 115_200)?;
+    connection.connect(app_handle.clone(), port_name, 115_200)?;
     connection.configure(new_device.config_id)?;
 
     let mut decoded_listener = connection

--- a/src-tauri/src/mesh/serial_connection.rs
+++ b/src-tauri/src/mesh/serial_connection.rs
@@ -169,7 +169,11 @@ impl SerialConnection {
             let recv_bytes = match read_port.read(incoming_serial_buf.as_mut_slice()) {
                 Ok(o) => o,
                 Err(ref e) if e.kind() == ErrorKind::TimedOut => continue,
-                Err(ref e) if e.kind() == ErrorKind::BrokenPipe => {
+                Err(ref e)
+                    if e.kind() == ErrorKind::BrokenPipe // Linux disconnect
+                        || e.kind() == ErrorKind::PermissionDenied // Windows disconnect
+                        =>
+                {
                     app_handle
                         .app_handle()
                         .emit_all("device_disconnect", "")

--- a/src-tauri/src/mesh/serial_connection.rs
+++ b/src-tauri/src/mesh/serial_connection.rs
@@ -3,11 +3,12 @@ use async_trait::async_trait;
 use prost::Message;
 use serialport::SerialPort;
 use std::{
-    io::ErrorKind::TimedOut,
+    io::ErrorKind,
     sync::{self, Arc, Mutex},
     thread::{self, JoinHandle},
     time::Duration,
 };
+use tauri::Manager;
 use tokio::sync::broadcast;
 
 #[derive(Clone, Copy, Debug, Default)]
@@ -101,7 +102,12 @@ impl SerialConnection {
         Ok(ports)
     }
 
-    pub fn connect(&mut self, port_name: String, baud_rate: u32) -> Result<(), String> {
+    pub fn connect(
+        &mut self,
+        app_handle: tauri::AppHandle,
+        port_name: String,
+        baud_rate: u32,
+    ) -> Result<(), String> {
         let mut port = serialport::new(port_name.clone(), baud_rate)
             .timeout(Duration::from_millis(10))
             .open()
@@ -162,7 +168,14 @@ impl SerialConnection {
 
             let recv_bytes = match read_port.read(incoming_serial_buf.as_mut_slice()) {
                 Ok(o) => o,
-                Err(ref e) if e.kind() == TimedOut => continue,
+                Err(ref e) if e.kind() == ErrorKind::TimedOut => continue,
+                Err(ref e) if e.kind() == ErrorKind::BrokenPipe => {
+                    app_handle
+                        .app_handle()
+                        .emit_all("device_disconnect", "")
+                        .expect("Could not dispatch disconnection event");
+                    break;
+                }
                 Err(err) => {
                     eprintln!("Read failed: {:?}", err);
                     continue;

--- a/src/features/device/deviceConnectionHandlerSagas.ts
+++ b/src/features/device/deviceConnectionHandlerSagas.ts
@@ -63,6 +63,7 @@ export function* handleDeviceDisconnectChannel(
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       yield take(channel);
       yield put(requestDisconnectFromDevice());
+      window.location.reload();
     }
   } catch (error) {
     yield call(handleSagaError, error);

--- a/src/features/device/deviceConnectionHandlerSagas.ts
+++ b/src/features/device/deviceConnectionHandlerSagas.ts
@@ -4,8 +4,10 @@ import { listen } from "@tauri-apps/api/event";
 
 import type { MeshDevice } from "@bindings/MeshDevice";
 import { deviceSliceActions } from "@features/device/deviceSlice";
+import { requestDisconnectFromDevice } from "@features/device/deviceActions";
 
 export type DeviceUpdateChannel = EventChannel<MeshDevice>;
+export type DeviceDisconnectChannel = EventChannel<string>;
 
 function* handleSagaError(error: unknown) {
   yield put({ type: "GENERAL_ERROR", payload: error });
@@ -32,6 +34,35 @@ export function* handleDeviceUpdateChannel(channel: DeviceUpdateChannel) {
       // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
       const meshDevice: MeshDevice = yield take(channel);
       yield put(deviceSliceActions.setDevice(meshDevice));
+    }
+  } catch (error) {
+    yield call(handleSagaError, error);
+  }
+}
+
+export const createDeviceDisconnectChannel = (): DeviceDisconnectChannel => {
+  return eventChannel((emitter) => {
+    listen<string>("device_disconnect", (event) => {
+      emitter(event.payload);
+    })
+      // .then((unlisten) => {
+      //   return unlisten;
+      // })
+      .catch(console.error);
+
+    // TODO UNLISTEN
+    return () => null;
+  });
+};
+
+export function* handleDeviceDisconnectChannel(
+  channel: DeviceDisconnectChannel
+) {
+  try {
+    while (true) {
+      // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+      yield take(channel);
+      yield put(requestDisconnectFromDevice());
     }
   } catch (error) {
     yield call(handleSagaError, error);

--- a/src/features/device/deviceSagas.ts
+++ b/src/features/device/deviceSagas.ts
@@ -4,7 +4,10 @@ import { all, call, put, takeEvery } from "redux-saga/effects";
 import {
   createDeviceUpdateChannel,
   handleDeviceUpdateChannel,
+  createDeviceDisconnectChannel,
+  handleDeviceDisconnectChannel,
   DeviceUpdateChannel,
+  DeviceDisconnectChannel,
 } from "@features/device/deviceConnectionHandlerSagas";
 import {
   requestAvailablePorts,
@@ -23,7 +26,15 @@ function* subscribeAll() {
     createDeviceUpdateChannel
   );
 
-  yield all([call(handleDeviceUpdateChannel, deviceUpdateChannel)]);
+  // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment
+  const deviceDisconnectChannel: DeviceDisconnectChannel = yield call(
+    createDeviceDisconnectChannel
+  );
+
+  yield all([
+    call(handleDeviceUpdateChannel, deviceUpdateChannel),
+    call(handleDeviceDisconnectChannel, deviceDisconnectChannel),
+  ]);
 }
 
 function* getAvailableSerialPortsWorker(


### PR DESCRIPTION
Currently, the application doesn't have UI for reconnecting to a disconnected device. This PR implements a flow that will automatically run the `disconnect_from_serial_port` command and then reload the UI's webview when a serial device loses connection with the application (a `BrokenPipe` error). This will allow the user to reconnect their device as if they just opened the app. This UX will be temporary until a reconnection flow can be established.

Closes #290 