### PR TITLE
Display title for unnamed channels

### DIFF
--- a/src/utils/messaging.ts
+++ b/src/utils/messaging.ts
@@ -2,7 +2,7 @@ import type { MeshChannel } from "@bindings/MeshChannel";
 
 export const getChannelName = (channel: MeshChannel): string => {
   if (channel.config.role === 1) return "Primary";
-  return channel.config.settings?.name ?? "Unnamed Channel";
+  return channel.config.settings?.name || "Unnamed Channel";
 };
 
 export const formatMessageUsername = (


### PR DESCRIPTION
This PR ensures that the `MessagingPage` component will show unnamed channels as `"Unnamed Channel"` instead of `""`.

Closes #281 