### PR TITLE
Added multi-channel sending support

### DIFF
--- a/src/components/Messaging/ChannelDetailView.tsx
+++ b/src/components/Messaging/ChannelDetailView.tsx
@@ -30,7 +30,9 @@ const ChannelDetailView = ({
       return;
     }
 
-    dispatch(requestSendMessage({ text: message, channel: 0 }));
+    dispatch(
+      requestSendMessage({ text: message, channel: channel.config.index })
+    );
   };
 
   return (

--- a/src/features/device/deviceActions.ts
+++ b/src/features/device/deviceActions.ts
@@ -13,9 +13,10 @@ export const requestDisconnectFromDevice = createAction(
   "@device/request-disconnect"
 );
 
-export const requestSendMessage = createAction<{ text: string; channel: 0 }>(
-  "@device/request-send-message"
-);
+export const requestSendMessage = createAction<{
+  text: string;
+  channel: number;
+}>("@device/request-send-message");
 
 export const requestUpdateUser = createAction<{ user: User }>(
   "@device/update-device-user"


### PR DESCRIPTION
This PR removes the restriction in `requestSendMessage` that forces sending of messages on only the `PRIMARY` channel (index 0).

Closes #270 