### PR TITLE
removed mocks at runtime:

### DIFF
--- a/src-tauri/src/mesh/device/handlers.rs
+++ b/src-tauri/src/mesh/device/handlers.rs
@@ -99,8 +99,6 @@ impl MeshDevice {
                         .map_err(|e| e.to_string())?;
 
                     self.add_position(PositionPacket { packet, data });
-                    //TODO: edge map generation from position packets should be temporary
-                    self.edges = mocks::mock_edge_map_from_loc_info(self.nodes.clone(), None);
                     device_updated = true;
                 }
                 protobufs::PortNum::PrivateApp => {


### PR DESCRIPTION
## Goal
One-line PR that remove mocks generation from position packets.

## Implementation
I was planning to use mock generation to proceed with graph edges/UI without having to have the firmware changes done, but since the forks for them are almost complete, this is no longer necessary. 

## Testing
No testing

## Development
This closes [this ticket](https://app.zenhub.com/workspaces/meshtastic---cosc-098-633f046aebd6cde319822187/issues/gh/dartmouth-cs98/project-22f-meshtastic/105) (on the class repository)