### PR TITLE
Removed TS generation test suite

### DIFF
--- a/package.json
+++ b/package.json
@@ -13,7 +13,7 @@
     "ui:test": "jest --passWithNoTests",
     "rust:dev": "tauri dev",
     "rust:build": "tauri build --",
-    "rust:test": "cd ./src-tauri; rm -rf ./bindings && cargo test"
+    "rust:test": "cd src-tauri; cargo test"
   },
   "dependencies": {
     "@heroicons/react": "^2.0.13",

--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -24,12 +24,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "Inflector"
-version = "0.11.4"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "fe438c63458706e03479442743baae6c88256498e6431708f6dfc520a26515d3"
-
-[[package]]
 name = "adler"
 version = "1.0.2"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -95,7 +89,6 @@ dependencies = [
  "tokio",
  "tracing",
  "tracing-subscriber",
- "ts-rs",
  "walkdir",
 ]
 
@@ -3338,15 +3331,6 @@ dependencies = [
 ]
 
 [[package]]
-name = "termcolor"
-version = "1.1.3"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "bab24d30b911b2376f3a13cc2cd443142f0c81dda04c118693e35b3835757755"
-dependencies = [
- "winapi-util",
-]
-
-[[package]]
 name = "thin-slice"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3569,29 +3553,6 @@ name = "try-lock"
 version = "0.2.3"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "59547bce71d9c38b83d9c0e92b6066c4253371f15005def0c30d9657f50c7642"
-
-[[package]]
-name = "ts-rs"
-version = "6.2.1"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "4added4070a4fdf9df03457206cd2e4b12417c8560a2954d91ffcbe60177a56a"
-dependencies = [
- "thiserror",
- "ts-rs-macros",
-]
-
-[[package]]
-name = "ts-rs-macros"
-version = "6.2.0"
-source = "registry+https://github.com/rust-lang/crates.io-index"
-checksum = "9f807fdb3151fee75df7485b901a89624358cd07a67a8fb1a5831bf5a07681ff"
-dependencies = [
- "Inflector",
- "proc-macro2",
- "quote",
- "syn",
- "termcolor",
-]
 
 [[package]]
 name = "typenum"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -34,7 +34,6 @@ prost = "0.11.0"
 bytes = "1.2.1"
 async-trait = "0.1.60"
 time = { version = "0.3.17", features = ["macros", "serde"] }
-ts-rs = "6.2.1"
 thiserror = "1.0.38"
 
 [features]

--- a/src-tauri/build.rs
+++ b/src-tauri/build.rs
@@ -26,13 +26,8 @@ fn main() -> std::io::Result<()> {
 
     let mut config = prost_build::Config::new();
 
-    config.type_attribute(
-        ".",
-        "#[derive(serde::Serialize, serde::Deserialize, ts_rs::TS)]",
-    );
+    config.type_attribute(".", "#[derive(serde::Serialize, serde::Deserialize)]");
     config.type_attribute(".", "#[serde(rename_all = \"camelCase\")]");
-    config.type_attribute(".", "#[ts(rename_all = \"camelCase\")]");
-    config.type_attribute(".", "#[ts(export, export_to = \"bindings/protobufs/\")]");
 
     config.compile_protos(&protos, &[protobufs_dir]).unwrap();
 

--- a/src-tauri/src/mesh/device/mod.rs
+++ b/src-tauri/src/mesh/device/mod.rs
@@ -1,7 +1,6 @@
 use app::protobufs;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
-use ts_rs::TS;
 
 use self::helpers::generate_rand_id;
 
@@ -10,10 +9,8 @@ pub mod handlers;
 pub mod helpers;
 pub mod state;
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub enum MeshDeviceStatus {
     DeviceRestarting,
     DeviceDisconnected,
@@ -30,111 +27,87 @@ impl Default for MeshDeviceStatus {
     }
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub struct MeshChannel {
     pub config: protobufs::Channel,
     pub last_interaction: u32,
     pub messages: Vec<ChannelMessageWithAck>,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub struct MeshNodeDeviceMetrics {
     metrics: protobufs::DeviceMetrics,
     timestamp: u32,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub struct MeshNodeEnvironmentMetrics {
     metrics: protobufs::EnvironmentMetrics,
     timestamp: u32,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub struct MeshNode {
     pub device_metrics: Vec<MeshNodeDeviceMetrics>,
     pub environment_metrics: Vec<MeshNodeEnvironmentMetrics>,
     pub data: protobufs::NodeInfo,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub struct TelemetryPacket {
     pub packet: protobufs::MeshPacket,
     pub data: protobufs::Telemetry,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub struct UserPacket {
     pub packet: protobufs::MeshPacket,
     pub data: protobufs::User,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub struct PositionPacket {
     pub packet: protobufs::MeshPacket,
     pub data: protobufs::Position,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub struct TextPacket {
     pub packet: protobufs::MeshPacket,
     pub data: String,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub struct WaypointPacket {
     pub packet: protobufs::MeshPacket,
     pub data: protobufs::Waypoint,
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub enum ChannelMessagePayload {
     Text(TextPacket),
     Waypoint(WaypointPacket),
 }
 
-#[derive(Clone, Debug, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub struct ChannelMessageWithAck {
     pub payload: ChannelMessagePayload,
     pub ack: bool,
 }
 
-#[derive(Clone, Debug, Default, Serialize, Deserialize, TS)]
+#[derive(Clone, Debug, Default, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
-#[ts(rename_all = "camelCase")]
-#[ts(export)]
 pub struct MeshDevice {
     pub config_id: u32,           // unique identifier for configuration flow packets
     pub ready: bool,              // is device configured to participate in mesh


### PR DESCRIPTION
This PR removes the existing `TS_RS` type generation suite, per #207.