### PR TITLE
Ajmcquilkin/integrate neighborinfo protos

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,3 +1,4 @@
 [submodule "src-tauri/protobufs"]
 	path = src-tauri/protobufs
-	url = https://github.com/meshtastic/protobufs
+	url = https://github.com/uhuruhashimoto/protobufs.git
+	branch = sim-working

--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src-tauri/protobufs"]
 	path = src-tauri/protobufs
 	url = https://github.com/uhuruhashimoto/protobufs.git
-	branch = sim-working
+	branch = development

--- a/src-tauri/src/mesh/device/connection.rs
+++ b/src-tauri/src/mesh/device/connection.rs
@@ -158,6 +158,7 @@ impl MeshDevice {
             id: generate_rand_id(),
             want_ack,
             channel,
+            last_sent_by_id: own_node_id,
         };
 
         if echo_response {

--- a/src-tauri/src/mesh/device/handlers.rs
+++ b/src-tauri/src/mesh/device/handlers.rs
@@ -8,8 +8,6 @@ use super::{
     WaypointPacket,
 };
 
-use crate::constructors::mock::mocks;
-
 impl MeshDevice {
     pub fn handle_packet_from_radio(
         &mut self,
@@ -74,126 +72,141 @@ impl MeshDevice {
         let mut device_updated = false;
 
         match variant {
-            protobufs::mesh_packet::PayloadVariant::Decoded(data) => match data.portnum() {
-                protobufs::PortNum::AdminApp => {
-                    println!("Admin application not yet supported in Rust");
-                }
-                protobufs::PortNum::AtakForwarder => {
-                    println!("ATAK forwarder not yet supported in Rust");
-                }
-                protobufs::PortNum::AudioApp => {
-                    println!("Audio app not yet supported in Rust");
-                }
-                protobufs::PortNum::IpTunnelApp => {
-                    println!("IP tunnel app not yet supported in Rust");
-                }
-                protobufs::PortNum::NodeinfoApp => {
-                    let data = protobufs::User::decode(data.payload.as_slice())
-                        .map_err(|e| e.to_string())?;
-
-                    self.add_user(UserPacket { packet, data });
-                    device_updated = true;
-                }
-                protobufs::PortNum::PositionApp => {
-                    let data = protobufs::Position::decode(data.payload.as_slice())
-                        .map_err(|e| e.to_string())?;
-
-                    self.add_position(PositionPacket { packet, data });
-                    device_updated = true;
-                }
-                protobufs::PortNum::PrivateApp => {
-                    println!("Private app not yet supported in Rust");
-                }
-                protobufs::PortNum::RangeTestApp => {
-                    println!("Range test app not yet supported in Rust");
-                }
-                protobufs::PortNum::RemoteHardwareApp => {
-                    println!("Remote hardware app not yet supported in Rust");
-                }
-                protobufs::PortNum::ReplyApp => {
-                    println!("Reply app not yet supported in Rust");
-                }
-                protobufs::PortNum::RoutingApp => {
-                    println!("Routing app not yet supported in Rust");
-                }
-                protobufs::PortNum::SerialApp => {
-                    println!("Serial app not yet supported in Rust");
-                }
-                protobufs::PortNum::SimulatorApp => {
-                    println!("Simulator app not yet supported in Rust");
-                }
-                protobufs::PortNum::StoreForwardApp => {
-                    println!("Store forward packets not yet supported in Rust");
-                }
-                protobufs::PortNum::TelemetryApp => {
-                    let data = protobufs::Telemetry::decode(data.payload.as_slice())
-                        .map_err(|e| e.to_string())?;
-
-                    self.set_device_metrics(TelemetryPacket { packet, data });
-                    device_updated = true;
-                }
-                protobufs::PortNum::TextMessageApp => {
-                    let data = String::from_utf8(data.payload).map_err(|e| e.to_string())?;
-                    self.add_text_message(TextPacket {
-                        packet: packet.clone(),
-                        data: data.clone(),
-                    });
-                    device_updated = true;
-
-                    if let Some(handle) = app_handle {
-                        let from_user_name = get_node_user_name(self, &packet.from)
-                            .unwrap_or(packet.from.to_string());
-
-                        let channel_name = get_channel_name(self, &packet.channel)
-                            .unwrap_or("Unknown channel".into());
-
-                        Notification::new(handle.config().tauri.bundle.identifier.clone())
-                            .title(format!("{} in {}", from_user_name, channel_name))
-                            .body(data)
-                            .notify(&handle)
+            protobufs::mesh_packet::PayloadVariant::Decoded(data) => {
+                println!("PortNum: {:?}", data.portnum);
+                match data.portnum() {
+                    protobufs::PortNum::AdminApp => {
+                        println!("Admin application not yet supported in Rust");
+                    }
+                    protobufs::PortNum::AtakForwarder => {
+                        println!("ATAK forwarder not yet supported in Rust");
+                    }
+                    protobufs::PortNum::AudioApp => {
+                        println!("Audio app not yet supported in Rust");
+                    }
+                    protobufs::PortNum::IpTunnelApp => {
+                        println!("IP tunnel app not yet supported in Rust");
+                    }
+                    protobufs::PortNum::NodeinfoApp => {
+                        let data = protobufs::User::decode(data.payload.as_slice())
                             .map_err(|e| e.to_string())?;
+
+                        self.add_user(UserPacket { packet, data });
+                        device_updated = true;
+                    }
+                    protobufs::PortNum::PositionApp => {
+                        let data = protobufs::Position::decode(data.payload.as_slice())
+                            .map_err(|e| e.to_string())?;
+
+                        self.add_position(PositionPacket { packet, data });
+                        device_updated = true;
+                    }
+                    protobufs::PortNum::PrivateApp => {
+                        println!("Private app not yet supported in Rust");
+                    }
+                    protobufs::PortNum::RangeTestApp => {
+                        println!("Range test app not yet supported in Rust");
+                    }
+                    protobufs::PortNum::RemoteHardwareApp => {
+                        println!("Remote hardware app not yet supported in Rust");
+                    }
+                    protobufs::PortNum::ReplyApp => {
+                        println!("Reply app not yet supported in Rust");
+                    }
+                    protobufs::PortNum::RoutingApp => {
+                        println!("Routing app not yet supported in Rust");
+                    }
+                    protobufs::PortNum::SerialApp => {
+                        println!("Serial app not yet supported in Rust");
+                    }
+                    protobufs::PortNum::SimulatorApp => {
+                        println!("Simulator app not yet supported in Rust");
+                    }
+                    protobufs::PortNum::StoreForwardApp => {
+                        println!("Store forward packets not yet supported in Rust");
+                    }
+                    protobufs::PortNum::TelemetryApp => {
+                        let data = protobufs::Telemetry::decode(data.payload.as_slice())
+                            .map_err(|e| e.to_string())?;
+
+                        self.set_device_metrics(TelemetryPacket { packet, data });
+                        device_updated = true;
+                    }
+                    protobufs::PortNum::TextMessageApp => {
+                        let data = String::from_utf8(data.payload).map_err(|e| e.to_string())?;
+                        self.add_text_message(TextPacket {
+                            packet: packet.clone(),
+                            data: data.clone(),
+                        });
+                        device_updated = true;
+
+                        if let Some(handle) = app_handle {
+                            let from_user_name = get_node_user_name(self, &packet.from)
+                                .unwrap_or(packet.from.to_string());
+
+                            let channel_name = get_channel_name(self, &packet.channel)
+                                .unwrap_or("Unknown channel".into());
+
+                            Notification::new(handle.config().tauri.bundle.identifier.clone())
+                                .title(format!("{} in {}", from_user_name, channel_name))
+                                .body(data)
+                                .notify(&handle)
+                                .map_err(|e| e.to_string())?;
+                        }
+                    }
+                    protobufs::PortNum::TextMessageCompressedApp => {
+                        eprintln!("Compressed text data not yet supported in Rust");
+                    }
+                    protobufs::PortNum::WaypointApp => {
+                        let data = protobufs::Waypoint::decode(data.payload.as_slice())
+                            .map_err(|e| e.to_string())?;
+
+                        self.add_waypoint(data.clone());
+                        self.add_waypoint_message(WaypointPacket {
+                            packet: packet.clone(),
+                            data: data.clone(),
+                        });
+                        device_updated = true;
+
+                        if let Some(handle) = app_handle {
+                            let from_user_name = get_node_user_name(self, &packet.from)
+                                .unwrap_or(packet.from.to_string());
+
+                            let channel_name = get_channel_name(self, &packet.channel)
+                                .unwrap_or("Unknown channel".into());
+
+                            Notification::new(handle.config().tauri.bundle.identifier.clone())
+                                .title(format!("{} in {}", from_user_name, channel_name))
+                                .body(format!(
+                                    "Sent waypoint \"{}\" at {}, {}",
+                                    data.name,
+                                    data.latitude_i as f32 / 1e7,
+                                    data.longitude_i as f32 / 1e7
+                                ))
+                                .notify(&handle)
+                                .map_err(|e| e.to_string())?;
+                        }
+                    }
+                    protobufs::PortNum::ZpsApp => {
+                        println!("ZPS app not yet supported in Rust");
+                    }
+                    protobufs::PortNum::NeighborinfoApp => {
+                        let data = protobufs::NeighborInfo::decode(data.payload.as_slice())
+                            .map_err(|e| e.to_string())?;
+
+                        println!("Neighbor info received: {:?}", data);
+                    }
+                    protobufs::PortNum::TracerouteApp => {
+                        println!("Traceroute app not yet supported in Rust");
+                    }
+                    protobufs::PortNum::UnknownApp => {
+                        println!("Unknown packet received");
+                    }
+                    protobufs::PortNum::Max => {
+                        eprintln!("This is not a real PortNum, why did this happen");
                     }
                 }
-                protobufs::PortNum::TextMessageCompressedApp => {
-                    eprintln!("Compressed text data not yet supported in Rust");
-                }
-                protobufs::PortNum::WaypointApp => {
-                    let data = protobufs::Waypoint::decode(data.payload.as_slice())
-                        .map_err(|e| e.to_string())?;
-
-                    self.add_waypoint(data.clone());
-                    self.add_waypoint_message(WaypointPacket {
-                        packet: packet.clone(),
-                        data: data.clone(),
-                    });
-                    device_updated = true;
-
-                    if let Some(handle) = app_handle {
-                        let from_user_name = get_node_user_name(self, &packet.from)
-                            .unwrap_or(packet.from.to_string());
-
-                        let channel_name = get_channel_name(self, &packet.channel)
-                            .unwrap_or("Unknown channel".into());
-
-                        Notification::new(handle.config().tauri.bundle.identifier.clone())
-                            .title(format!("{} in {}", from_user_name, channel_name))
-                            .body(format!(
-                                "Sent waypoint \"{}\" at {}, {}",
-                                data.name,
-                                data.latitude_i as f32 / 1e7,
-                                data.longitude_i as f32 / 1e7
-                            ))
-                            .notify(&handle)
-                            .map_err(|e| e.to_string())?;
-                    }
-                }
-                protobufs::PortNum::ZpsApp => {
-                    println!("ZPS app not yet supported in Rust");
-                }
-                _ => {
-                    println!("Unknown packet received");
-                }
-            },
+            }
             protobufs::mesh_packet::PayloadVariant::Encrypted(e) => {
                 eprintln!("Encrypted packets not yet supported in Rust: {:#?}", e);
             }

--- a/src-tauri/src/mesh/device/handlers.rs
+++ b/src-tauri/src/mesh/device/handlers.rs
@@ -5,7 +5,7 @@ use tauri::api::notification::Notification;
 use super::{
     helpers::{get_channel_name, get_current_time_u32, get_node_user_name},
     MeshChannel, MeshDevice, PositionPacket, TelemetryPacket, TextPacket, UserPacket,
-    WaypointPacket,
+    WaypointPacket, NeighborInfoPacket
 };
 
 impl MeshDevice {
@@ -194,7 +194,11 @@ impl MeshDevice {
                         let data = protobufs::NeighborInfo::decode(data.payload.as_slice())
                             .map_err(|e| e.to_string())?;
 
-                        println!("Neighbor info received: {:?}", data);
+                        self.add_neighborinfo(NeighborInfoPacket {
+                                packet: packet.clone(),
+                                data: data.clone(),
+                        });
+                        device_updated = true;
                     }
                     protobufs::PortNum::TracerouteApp => {
                         println!("Traceroute app not yet supported in Rust");

--- a/src-tauri/src/mesh/device/handlers.rs
+++ b/src-tauri/src/mesh/device/handlers.rs
@@ -4,8 +4,8 @@ use tauri::api::notification::Notification;
 
 use super::{
     helpers::{get_channel_name, get_current_time_u32, get_node_user_name},
-    MeshChannel, MeshDevice, PositionPacket, TelemetryPacket, TextPacket, UserPacket,
-    WaypointPacket, NeighborInfoPacket
+    MeshChannel, MeshDevice, NeighborInfoPacket, PositionPacket, TelemetryPacket, TextPacket,
+    UserPacket, WaypointPacket,
 };
 
 impl MeshDevice {
@@ -72,145 +72,142 @@ impl MeshDevice {
         let mut device_updated = false;
 
         match variant {
-            protobufs::mesh_packet::PayloadVariant::Decoded(data) => {
-                println!("PortNum: {:?}", data.portnum);
-                match data.portnum() {
-                    protobufs::PortNum::AdminApp => {
-                        println!("Admin application not yet supported in Rust");
-                    }
-                    protobufs::PortNum::AtakForwarder => {
-                        println!("ATAK forwarder not yet supported in Rust");
-                    }
-                    protobufs::PortNum::AudioApp => {
-                        println!("Audio app not yet supported in Rust");
-                    }
-                    protobufs::PortNum::IpTunnelApp => {
-                        println!("IP tunnel app not yet supported in Rust");
-                    }
-                    protobufs::PortNum::NodeinfoApp => {
-                        let data = protobufs::User::decode(data.payload.as_slice())
+            protobufs::mesh_packet::PayloadVariant::Decoded(data) => match data.portnum() {
+                protobufs::PortNum::AdminApp => {
+                    println!("Admin application not yet supported in Rust");
+                }
+                protobufs::PortNum::AtakForwarder => {
+                    println!("ATAK forwarder not yet supported in Rust");
+                }
+                protobufs::PortNum::AudioApp => {
+                    println!("Audio app not yet supported in Rust");
+                }
+                protobufs::PortNum::IpTunnelApp => {
+                    println!("IP tunnel app not yet supported in Rust");
+                }
+                protobufs::PortNum::NodeinfoApp => {
+                    let data = protobufs::User::decode(data.payload.as_slice())
+                        .map_err(|e| e.to_string())?;
+
+                    self.add_user(UserPacket { packet, data });
+                    device_updated = true;
+                }
+                protobufs::PortNum::PositionApp => {
+                    let data = protobufs::Position::decode(data.payload.as_slice())
+                        .map_err(|e| e.to_string())?;
+
+                    self.add_position(PositionPacket { packet, data });
+                    device_updated = true;
+                }
+                protobufs::PortNum::PrivateApp => {
+                    println!("Private app not yet supported in Rust");
+                }
+                protobufs::PortNum::RangeTestApp => {
+                    println!("Range test app not yet supported in Rust");
+                }
+                protobufs::PortNum::RemoteHardwareApp => {
+                    println!("Remote hardware app not yet supported in Rust");
+                }
+                protobufs::PortNum::ReplyApp => {
+                    println!("Reply app not yet supported in Rust");
+                }
+                protobufs::PortNum::RoutingApp => {
+                    println!("Routing app not yet supported in Rust");
+                }
+                protobufs::PortNum::SerialApp => {
+                    println!("Serial app not yet supported in Rust");
+                }
+                protobufs::PortNum::SimulatorApp => {
+                    println!("Simulator app not yet supported in Rust");
+                }
+                protobufs::PortNum::StoreForwardApp => {
+                    println!("Store forward packets not yet supported in Rust");
+                }
+                protobufs::PortNum::TelemetryApp => {
+                    let data = protobufs::Telemetry::decode(data.payload.as_slice())
+                        .map_err(|e| e.to_string())?;
+
+                    self.set_device_metrics(TelemetryPacket { packet, data });
+                    device_updated = true;
+                }
+                protobufs::PortNum::TextMessageApp => {
+                    let data = String::from_utf8(data.payload).map_err(|e| e.to_string())?;
+                    self.add_text_message(TextPacket {
+                        packet: packet.clone(),
+                        data: data.clone(),
+                    });
+                    device_updated = true;
+
+                    if let Some(handle) = app_handle {
+                        let from_user_name = get_node_user_name(self, &packet.from)
+                            .unwrap_or(packet.from.to_string());
+
+                        let channel_name = get_channel_name(self, &packet.channel)
+                            .unwrap_or("Unknown channel".into());
+
+                        Notification::new(handle.config().tauri.bundle.identifier.clone())
+                            .title(format!("{} in {}", from_user_name, channel_name))
+                            .body(data)
+                            .notify(&handle)
                             .map_err(|e| e.to_string())?;
-
-                        self.add_user(UserPacket { packet, data });
-                        device_updated = true;
-                    }
-                    protobufs::PortNum::PositionApp => {
-                        let data = protobufs::Position::decode(data.payload.as_slice())
-                            .map_err(|e| e.to_string())?;
-
-                        self.add_position(PositionPacket { packet, data });
-                        device_updated = true;
-                    }
-                    protobufs::PortNum::PrivateApp => {
-                        println!("Private app not yet supported in Rust");
-                    }
-                    protobufs::PortNum::RangeTestApp => {
-                        println!("Range test app not yet supported in Rust");
-                    }
-                    protobufs::PortNum::RemoteHardwareApp => {
-                        println!("Remote hardware app not yet supported in Rust");
-                    }
-                    protobufs::PortNum::ReplyApp => {
-                        println!("Reply app not yet supported in Rust");
-                    }
-                    protobufs::PortNum::RoutingApp => {
-                        println!("Routing app not yet supported in Rust");
-                    }
-                    protobufs::PortNum::SerialApp => {
-                        println!("Serial app not yet supported in Rust");
-                    }
-                    protobufs::PortNum::SimulatorApp => {
-                        println!("Simulator app not yet supported in Rust");
-                    }
-                    protobufs::PortNum::StoreForwardApp => {
-                        println!("Store forward packets not yet supported in Rust");
-                    }
-                    protobufs::PortNum::TelemetryApp => {
-                        let data = protobufs::Telemetry::decode(data.payload.as_slice())
-                            .map_err(|e| e.to_string())?;
-
-                        self.set_device_metrics(TelemetryPacket { packet, data });
-                        device_updated = true;
-                    }
-                    protobufs::PortNum::TextMessageApp => {
-                        let data = String::from_utf8(data.payload).map_err(|e| e.to_string())?;
-                        self.add_text_message(TextPacket {
-                            packet: packet.clone(),
-                            data: data.clone(),
-                        });
-                        device_updated = true;
-
-                        if let Some(handle) = app_handle {
-                            let from_user_name = get_node_user_name(self, &packet.from)
-                                .unwrap_or(packet.from.to_string());
-
-                            let channel_name = get_channel_name(self, &packet.channel)
-                                .unwrap_or("Unknown channel".into());
-
-                            Notification::new(handle.config().tauri.bundle.identifier.clone())
-                                .title(format!("{} in {}", from_user_name, channel_name))
-                                .body(data)
-                                .notify(&handle)
-                                .map_err(|e| e.to_string())?;
-                        }
-                    }
-                    protobufs::PortNum::TextMessageCompressedApp => {
-                        eprintln!("Compressed text data not yet supported in Rust");
-                    }
-                    protobufs::PortNum::WaypointApp => {
-                        let data = protobufs::Waypoint::decode(data.payload.as_slice())
-                            .map_err(|e| e.to_string())?;
-
-                        self.add_waypoint(data.clone());
-                        self.add_waypoint_message(WaypointPacket {
-                            packet: packet.clone(),
-                            data: data.clone(),
-                        });
-                        device_updated = true;
-
-                        if let Some(handle) = app_handle {
-                            let from_user_name = get_node_user_name(self, &packet.from)
-                                .unwrap_or(packet.from.to_string());
-
-                            let channel_name = get_channel_name(self, &packet.channel)
-                                .unwrap_or("Unknown channel".into());
-
-                            Notification::new(handle.config().tauri.bundle.identifier.clone())
-                                .title(format!("{} in {}", from_user_name, channel_name))
-                                .body(format!(
-                                    "Sent waypoint \"{}\" at {}, {}",
-                                    data.name,
-                                    data.latitude_i as f32 / 1e7,
-                                    data.longitude_i as f32 / 1e7
-                                ))
-                                .notify(&handle)
-                                .map_err(|e| e.to_string())?;
-                        }
-                    }
-                    protobufs::PortNum::ZpsApp => {
-                        println!("ZPS app not yet supported in Rust");
-                    }
-                    protobufs::PortNum::NeighborinfoApp => {
-                        let data = protobufs::NeighborInfo::decode(data.payload.as_slice())
-                            .map_err(|e| e.to_string())?;
-
-                        self.add_neighborinfo(NeighborInfoPacket {
-                                packet: packet.clone(),
-                                data: data.clone(),
-                        });
-                        device_updated = true;
-                    }
-                    protobufs::PortNum::TracerouteApp => {
-                        println!("Traceroute app not yet supported in Rust");
-                    }
-                    protobufs::PortNum::UnknownApp => {
-                        println!("Unknown packet received");
-                    }
-                    protobufs::PortNum::Max => {
-                        eprintln!("This is not a real PortNum, why did this happen");
                     }
                 }
-            }
+                protobufs::PortNum::TextMessageCompressedApp => {
+                    eprintln!("Compressed text data not yet supported in Rust");
+                }
+                protobufs::PortNum::WaypointApp => {
+                    let data = protobufs::Waypoint::decode(data.payload.as_slice())
+                        .map_err(|e| e.to_string())?;
+
+                    self.add_waypoint(data.clone());
+                    self.add_waypoint_message(WaypointPacket {
+                        packet: packet.clone(),
+                        data: data.clone(),
+                    });
+                    device_updated = true;
+
+                    if let Some(handle) = app_handle {
+                        let from_user_name = get_node_user_name(self, &packet.from)
+                            .unwrap_or(packet.from.to_string());
+
+                        let channel_name = get_channel_name(self, &packet.channel)
+                            .unwrap_or("Unknown channel".into());
+
+                        Notification::new(handle.config().tauri.bundle.identifier.clone())
+                            .title(format!("{} in {}", from_user_name, channel_name))
+                            .body(format!(
+                                "Sent waypoint \"{}\" at {}, {}",
+                                data.name,
+                                data.latitude_i as f32 / 1e7,
+                                data.longitude_i as f32 / 1e7
+                            ))
+                            .notify(&handle)
+                            .map_err(|e| e.to_string())?;
+                    }
+                }
+                protobufs::PortNum::ZpsApp => {
+                    println!("ZPS app not yet supported in Rust");
+                }
+                protobufs::PortNum::NeighborinfoApp => {
+                    let data = protobufs::NeighborInfo::decode(data.payload.as_slice())
+                        .map_err(|e| e.to_string())?;
+
+                    self.add_neighborinfo(NeighborInfoPacket {
+                        packet: packet.clone(),
+                        data: data.clone(),
+                    });
+                    device_updated = true;
+                }
+                protobufs::PortNum::TracerouteApp => {
+                    println!("Traceroute app not yet supported in Rust");
+                }
+                protobufs::PortNum::UnknownApp => {
+                    println!("Unknown packet received");
+                }
+                protobufs::PortNum::Max => {
+                    eprintln!("This is not a real PortNum, why did this happen");
+                }
+            },
             protobufs::mesh_packet::PayloadVariant::Encrypted(e) => {
                 eprintln!("Encrypted packets not yet supported in Rust: {:#?}", e);
             }

--- a/src-tauri/src/mesh/device/mod.rs
+++ b/src-tauri/src/mesh/device/mod.rs
@@ -1,4 +1,4 @@
-use app::protobufs;
+use app::protobufs::{self, Neighbor};
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
@@ -80,6 +80,12 @@ pub struct PositionPacket {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+pub struct NeighborInfoPacket {
+    pub packet: protobufs::MeshPacket,
+    pub data: protobufs::NeighborInfo,
+}
+#[derive(Clone, Debug, Serialize, Deserialize)]
+#[serde(rename_all = "camelCase")]
 pub struct TextPacket {
     pub packet: protobufs::MeshPacket,
     pub data: String,
@@ -120,6 +126,7 @@ pub struct MeshDevice {
     pub region_unset: bool,                     // flag for whether device has an unset LoRa region
     pub device_metrics: protobufs::DeviceMetrics, // information about functioning of device (e.g. battery level)
     pub waypoints: HashMap<u32, protobufs::Waypoint>, // updatable GPS positions managed by this device
+    pub neighbors: HashMap<u32, protobufs::NeighborInfo>, //updated packets from each node containing their neighbors
 }
 
 impl MeshDevice {

--- a/src-tauri/src/mesh/device/mod.rs
+++ b/src-tauri/src/mesh/device/mod.rs
@@ -1,4 +1,4 @@
-use app::protobufs::{self, Neighbor};
+use app::protobufs;
 use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 

--- a/src-tauri/src/mesh/device/state.rs
+++ b/src-tauri/src/mesh/device/state.rs
@@ -121,6 +121,12 @@ impl MeshDevice {
                             timestamp: get_current_time_u32(),
                         });
                     }
+                    protobufs::telemetry::Variant::AirQualityMetrics(air_quality_metrics) => {
+                        println!(
+                            "Received air quality metrics, not handling: {:?}",
+                            air_quality_metrics
+                        );
+                    }
                 }
             }
         }

--- a/src-tauri/src/mesh/device/state.rs
+++ b/src-tauri/src/mesh/device/state.rs
@@ -4,7 +4,7 @@ use super::helpers::get_current_time_u32;
 use super::{
     ChannelMessagePayload, ChannelMessageWithAck, MeshChannel, MeshDevice, MeshDeviceStatus,
     MeshNode, MeshNodeDeviceMetrics, MeshNodeEnvironmentMetrics, PositionPacket, TelemetryPacket,
-    TextPacket, UserPacket, WaypointPacket,
+    TextPacket, UserPacket, WaypointPacket, NeighborInfoPacket
 };
 
 impl MeshDevice {
@@ -237,6 +237,26 @@ impl MeshDevice {
                 },
             );
         }
+    }
+
+    pub fn add_neighborinfo(&mut self, neighborinfo: NeighborInfoPacket) {
+        let existing_node = self.neighbors.get_mut(&neighborinfo.packet.from);
+
+        if existing_node.is_some() {
+            println!(
+                "Updating neighborinfo of existing node {:?}: {:?}",
+                neighborinfo.packet.from, neighborinfo.data
+            );
+        } else {
+            println!(
+                "Adding neighborinfo to new node {:?}: {:?}",
+                neighborinfo.packet.from, neighborinfo.data
+            );
+        }
+        self.neighbors.insert(
+            neighborinfo.packet.from,
+            neighborinfo.data,
+        );
     }
 
     pub fn add_text_message(&mut self, message: TextPacket) {

--- a/src/components/NodeSearch/NodeSearchResult.tsx
+++ b/src/components/NodeSearch/NodeSearchResult.tsx
@@ -63,7 +63,7 @@ const NodeSearchResult = ({
       <_NodeSearchResultIcon nodeState={nodeState} />
 
       <div className={`flex-grow ${colorClasses.text}`}>
-        <p className="text-lg font-semibold">
+        <p className="text-lg font-semibold whitespace-nowrap overflow-hidden text-ellipsis">
           {node.data.user?.longName ?? node.data.num}
           <span className="text-sm font-normal pl-2">
             {lastPacketTime ? (


### PR DESCRIPTION
## Goal
This PR sets up the basics for our backend to receive `NeighborInfo` packets from firmware.

## Implementation
- This PR adds a handler for packets from the `NeighborInfo` (port 71).
- This PR adds a `NeighborInfoPacket` struct to pass the packet to the handler.
- This PR adds a `neighbors` field to the `MeshDevice` struct, intended to directly store `NeighborInfo` packets as they come in.
- This PR re-points the `protobufs` submodule to the `development` branch of the fork (https://github.com/uhuruhashimoto/protobufs), which contains the `NeighborInfo` protobuf, changes to `DeviceOnly` proto, and changes to `MeshPacket` (to pass in the info that will later be appended to the header). 

## Testing
Tested in hardware with two nodes with flashed firmware from `development` fork of https://github.com/uhuruhashimoto/firmware