### PR TITLE
Adding position info to new node struct fields when graph is created

### DIFF
--- a/src-tauri/src/constructors/init/init_edge_map.rs
+++ b/src-tauri/src/constructors/init/init_edge_map.rs
@@ -1,7 +1,6 @@
 use app::protobufs::{Neighbor, NeighborInfo};
 use std::collections::HashMap;
 
-
 /*
 * We're given a HashMap of NeighborInfo packets, each of which is considered to be the most up-to-date
 * edge info we have for a node. When we create edges, we want to keep this idea of freshness in mind. If
@@ -26,7 +25,11 @@ pub fn init_edge_map(neighbors: &HashMap<u32, NeighborInfo>) -> HashMap<(u32, u3
             match opposite_neighbor {
                 // If the opposite neighbor is found on a recent packet, we take the most recent SNR
                 Some(opposite_neighbor) => {
-                    let most_recent_data = if neighbor.rx_time > opposite_neighbor.rx_time {neighbor} else {&opposite_neighbor};
+                    let most_recent_data = if neighbor.rx_time > opposite_neighbor.rx_time {
+                        neighbor
+                    } else {
+                        &opposite_neighbor
+                    };
                     snr_hashmap.insert(
                         as_key(node_1, node_2),
                         (most_recent_data.snr as f64, most_recent_data.rx_time as u64),
@@ -78,9 +81,7 @@ pub fn check_other_node_agrees(
             }
             None
         }
-        _ => {
-            None
-        }
+        _ => None,
     }
 }
 

--- a/src-tauri/src/constructors/init/init_graph.rs
+++ b/src-tauri/src/constructors/init/init_graph.rs
@@ -64,7 +64,7 @@ pub fn add_node_and_location_to_graph(
                 node.longitude = node_pos.longitude_i as f64 * LON_CONVERSION_FACTOR;
                 node.altitude = node_pos.altitude as f64 * ALT_CONVERSION_FACTOR;
                 node.speed = node_pos.ground_speed as f64 * SPEED_CONVERSION_FACTOR;
-                node.direction = 0.0;
+                node.direction = node_pos.ground_speed as f64;
             } else {
                 println!("We do not have position info for node {}", name);
             }

--- a/src-tauri/src/constructors/init/init_graph.rs
+++ b/src-tauri/src/constructors/init/init_graph.rs
@@ -56,7 +56,7 @@ pub fn add_node_and_location_to_graph(
 ) -> NodeIndex {
     let name: String = node_id.to_string();
     if !graph.contains_node(name.clone()) {
-        let mut node = Node::new(name);
+        let mut node = Node::new(name.clone());
         if let Some(node_loc) = node_loc {
             let node_pos = &node_loc.data.position;
             if let Some(node_pos) = node_pos {
@@ -65,6 +65,8 @@ pub fn add_node_and_location_to_graph(
                 node.altitude = node_pos.altitude as f64 * ALT_CONVERSION_FACTOR;
                 node.speed = node_pos.ground_speed as f64 * SPEED_CONVERSION_FACTOR;
                 node.direction = 0.0;
+            } else {
+                println!("We do not have position info for node {}", name);
             }
         }
         return graph.add_node_from_struct(node);

--- a/src-tauri/src/constructors/init/init_graph.rs
+++ b/src-tauri/src/constructors/init/init_graph.rs
@@ -68,8 +68,19 @@ pub fn add_node_and_location_to_graph(
             }
         }
         return graph.add_node_from_struct(node);
+    } else {
+        let node_idx = graph.get_node_idx(name.clone());
+        let node = graph.get_node_mut(node_idx);
+        if let Some(node_loc) = node_loc {
+            let node_pos = &node_loc.data.position;
+            if let Some(node_pos) = node_pos {
+                let latitude = node_pos.latitude_i as f64 * LAT_CONVERSION_FACTOR;
+                let longitude = node_pos.longitude_i as f64 * LON_CONVERSION_FACTOR;
+                let altitude = node_pos.altitude as f64 * ALT_CONVERSION_FACTOR;
+                node.set_gps(longitude, latitude, altitude);
+            }
+        }
     }
-    // TODO: this doesn't actually update nodes
     graph.get_node_idx(name)
 }
 

--- a/src-tauri/src/constructors/init/init_graph.rs
+++ b/src-tauri/src/constructors/init/init_graph.rs
@@ -1,6 +1,10 @@
 use crate::analytics::aux_functions::edge_factory::edge_factory;
+use crate::data_conversion::distance_constants::{
+    ALT_CONVERSION_FACTOR, LAT_CONVERSION_FACTOR, LON_CONVERSION_FACTOR, SPEED_CONVERSION_FACTOR,
+};
 use crate::data_conversion::distance_conversion::get_distance;
 use crate::graph::graph_ds::Graph;
+use crate::graph::node::Node;
 use crate::mesh::device::MeshNode;
 use petgraph::graph::NodeIndex;
 use std::collections::HashMap;
@@ -20,13 +24,11 @@ pub fn init_graph(
     for neighbor_pair in snr_hashmap {
         let node_id = neighbor_pair.0 .0;
         let neighbor_id = neighbor_pair.0 .1;
-        add_node_to_graph_if_not_exists(&mut graph, node_id);
-        add_node_to_graph_if_not_exists(&mut graph, neighbor_id);
-        let node_idx = graph.get_node_idx(node_id.to_string());
-        let neighbor_idx = graph.get_node_idx(neighbor_id.to_string());
         let snr = neighbor_pair.1 .0;
         let node_loc = loc_hashmap.get(&node_id);
         let neighbor_loc = loc_hashmap.get(&neighbor_id);
+        let node_idx = add_node_and_location_to_graph(node_id, &mut graph, node_loc);
+        let neighbor_idx = add_node_and_location_to_graph(neighbor_id, &mut graph, neighbor_loc);
         let distance = get_distance(node_loc, neighbor_loc);
         edge_left_endpoints.push(node_idx);
         edge_right_endpoints.push(neighbor_idx);
@@ -47,11 +49,28 @@ pub fn init_graph(
     graph
 }
 
-pub fn add_node_to_graph_if_not_exists(graph: &mut Graph, node_id: u32) {
+pub fn add_node_and_location_to_graph(
+    node_id: u32,
+    graph: &mut Graph,
+    node_loc: Option<&MeshNode>,
+) -> NodeIndex {
     let name: String = node_id.to_string();
     if !graph.contains_node(name.clone()) {
-        graph.add_node(name);
+        let mut node = Node::new(name);
+        if let Some(node_loc) = node_loc {
+            let node_pos = &node_loc.data.position;
+            if let Some(node_pos) = node_pos {
+                node.latitude = node_pos.latitude_i as f64 * LAT_CONVERSION_FACTOR;
+                node.longitude = node_pos.longitude_i as f64 * LON_CONVERSION_FACTOR;
+                node.altitude = node_pos.altitude as f64 * ALT_CONVERSION_FACTOR;
+                node.speed = node_pos.ground_speed as f64 * SPEED_CONVERSION_FACTOR;
+                node.direction = 0.0;
+            }
+        }
+        return graph.add_node_from_struct(node);
     }
+    // TODO: this doesn't actually update nodes
+    graph.get_node_idx(name)
 }
 
 #[cfg(test)]

--- a/src-tauri/src/constructors/init/init_graph.rs
+++ b/src-tauri/src/constructors/init/init_graph.rs
@@ -64,7 +64,7 @@ pub fn add_node_and_location_to_graph(
                 node.longitude = node_pos.longitude_i as f64 * LON_CONVERSION_FACTOR;
                 node.altitude = node_pos.altitude as f64 * ALT_CONVERSION_FACTOR;
                 node.speed = node_pos.ground_speed as f64 * SPEED_CONVERSION_FACTOR;
-                node.direction = node_pos.ground_speed as f64;
+                node.direction = node_pos.ground_track as f64;
             } else {
                 println!("We do not have position info for node {}", name);
             }

--- a/src-tauri/src/data_conversion/distance_constants.rs
+++ b/src-tauri/src/data_conversion/distance_constants.rs
@@ -8,3 +8,5 @@ pub const LON_CONVERSION_FACTOR: f64 = 1e-7;
 pub const ALT_CONVERSION_FACTOR: f64 = 1.0;
 // radius of the earth in km
 pub const RADIUS_EARTH_KM: f64 = 6371.0;
+// speed in m/s
+pub const SPEED_CONVERSION_FACTOR: f64 = 1.0;

--- a/src-tauri/src/data_conversion/mod.rs
+++ b/src-tauri/src/data_conversion/mod.rs
@@ -1,2 +1,2 @@
-mod distance_constants;
+pub(crate) mod distance_constants;
 pub(crate) mod distance_conversion;

--- a/src-tauri/src/graph/graph_ds.rs
+++ b/src-tauri/src/graph/graph_ds.rs
@@ -7,8 +7,8 @@ use crate::graph::node::Node;
 use nalgebra::DMatrix;
 use petgraph::prelude::*;
 use petgraph::stable_graph::StableUnGraph;
-use std::collections::HashMap;
 use serde::{Deserialize, Serialize};
+use std::collections::HashMap;
 
 #[derive(Serialize, Deserialize)]
 pub struct Graph {


### PR DESCRIPTION
## Goal
Correctly adds node location info to nodes when creating graph

## Implementation
I added a `add_node_and_location` function to `init_graph` that adds position info to the node fields when it creates nodes. Node: we're not updating nodes right now, just creating them since we're creating an entirely new graph every run. Eventually, update node locations instead of creating new nodes.

## Testing
Hardware tested with hardcoded fields; they come through and the graph has the correct number of nodes. 