### PR TITLE
Allowed for text and waypoint packets to be displayed in messaging UI

### DIFF
--- a/src-tauri/bindings/ChannelMessagePayload.ts
+++ b/src-tauri/bindings/ChannelMessagePayload.ts
@@ -2,4 +2,4 @@
 import type { TextPacket } from "./TextPacket";
 import type { WaypointPacket } from "./WaypointPacket";
 
-export type ChannelMessagePayload = { text: TextPacket };
+export type ChannelMessagePayload = ({ type: "text" } & TextPacket) | ({ type: "waypoint" } & WaypointPacket);

--- a/src-tauri/src/mesh/device/mod.rs
+++ b/src-tauri/src/mesh/device/mod.rs
@@ -101,6 +101,7 @@ pub struct WaypointPacket {
 
 #[derive(Clone, Debug, Serialize, Deserialize)]
 #[serde(rename_all = "camelCase")]
+#[serde(tag = "type")]
 pub enum ChannelMessagePayload {
     Text(TextPacket),
     Waypoint(WaypointPacket),

--- a/src/components/Messaging/ChannelDetailView.tsx
+++ b/src/components/Messaging/ChannelDetailView.tsx
@@ -48,7 +48,7 @@ const ChannelDetailView = ({
             <TextMessageBubble
               className="pr-6"
               message={m}
-              key={m.payload.text.packet.id}
+              key={m.payload.packet.id}
             />
           ))}
         </div>

--- a/src/components/Messaging/ChannelListElement.tsx
+++ b/src/components/Messaging/ChannelListElement.tsx
@@ -1,6 +1,9 @@
 import React from "react";
 import type { MeshChannel } from "@bindings/MeshChannel";
-import { getChannelName } from "@utils/messaging";
+import {
+  getChannelName,
+  getLastChannelMessageDisplayText,
+} from "@utils/messaging";
 
 export interface IChannelListElementProps {
   channel: MeshChannel;
@@ -47,8 +50,7 @@ const ChannelListElement = ({
           </p>
         </div>
         <p className="min-w-full text-left whitespace-nowrap overflow-hidden overflow-ellipsis text-base font-normal text-gray-400">
-          {lastMessage?.payload.text.data ??
-            "No messages received on this channel."}
+          {getLastChannelMessageDisplayText(lastMessage)}
         </p>
       </button>
     );
@@ -74,8 +76,7 @@ const ChannelListElement = ({
         </p>
       </div>
       <p className="min-w-full text-left whitespace-nowrap overflow-hidden overflow-ellipsis text-base font-normal text-gray-500">
-        {lastMessage?.payload.text.data ??
-          "No messages received on this channel."}
+        {getLastChannelMessageDisplayText(lastMessage)}
       </p>
     </button>
   );

--- a/src/components/Messaging/TextMessageBubble.tsx
+++ b/src/components/Messaging/TextMessageBubble.tsx
@@ -6,7 +6,11 @@ import {
   selectUserByNodeId,
   selectConnectedDeviceNodeId,
 } from "@features/device/deviceSelectors";
-import { formatMessageTime, formatMessageUsername } from "@utils/messaging";
+import {
+  formatMessageTime,
+  formatMessageUsername,
+  getPacketDisplayText,
+} from "@utils/messaging";
 
 export interface ITextMessageBubbleProps {
   message: ChannelMessageWithState;
@@ -31,11 +35,12 @@ const TextMessageBubble = ({
   message,
   className = "",
 }: ITextMessageBubbleProps) => {
-  const { packet } = message.payload.text;
+  const { packet } = message.payload;
+
   const user = useSelector(selectUserByNodeId(packet.from));
   const ownNodeId = useSelector(selectConnectedDeviceNodeId());
 
-  const { displayText, isSelf } = formatMessageUsername(
+  const { displayText: usernameDisplayText, isSelf } = formatMessageUsername(
     user?.longName,
     ownNodeId ?? 0,
     packet.from
@@ -51,12 +56,12 @@ const TextMessageBubble = ({
             {formatMessageTime(packet.rxTime)}
           </span>
           <span className="text-sm font-semibold text-gray-700">
-            {displayText}
+            {usernameDisplayText}
           </span>
         </p>
 
         <p className="ml-auto px-3 py-2 w-fit max-w-[40%] rounded-l-lg rounded-br-lg bg-gray-700 text-sm font-medium text-gray-100 border border-gray-400 break-words">
-          {message.payload.text.data}
+          {getPacketDisplayText(message.payload)}
         </p>
 
         <p
@@ -74,7 +79,7 @@ const TextMessageBubble = ({
     <div className={`${className}`}>
       <p className="flex flex-row justify-start mb-1 gap-2 items-baseline">
         <span className="text-sm font-semibold text-gray-700">
-          {displayText}
+          {usernameDisplayText}
         </span>
         <span className="text-xs font-semibold text-gray-400">
           {formatMessageTime(packet.rxTime)}
@@ -82,7 +87,7 @@ const TextMessageBubble = ({
       </p>
 
       <p className="mr-auto px-3 py-2 w-fit max-w-[40%] rounded-r-lg rounded-bl-lg bg-white text-sm font-normal text-gray-700 border border-gray-200 break-words">
-        {message.payload.text.data}
+        {getPacketDisplayText(message.payload)}
       </p>
     </div>
   );

--- a/src/utils/messaging.ts
+++ b/src/utils/messaging.ts
@@ -1,3 +1,5 @@
+import type { ChannelMessagePayload } from "@bindings/ChannelMessagePayload";
+import type { ChannelMessageWithState } from "@bindings/ChannelMessageWithState";
 import type { MeshChannel } from "@bindings/MeshChannel";
 
 export const getChannelName = (channel: MeshChannel): string => {
@@ -8,10 +10,11 @@ export const getChannelName = (channel: MeshChannel): string => {
 export const formatMessageUsername = (
   longName: string | undefined,
   ownNodeId: number,
-  from: number
+  from: number,
 ): { displayText: string; isSelf: boolean } => {
-  if (from === 0 || from == ownNodeId)
+  if (from === 0 || from == ownNodeId) {
     return { displayText: "You", isSelf: true };
+  }
   if (!longName) return { displayText: `${from}`, isSelf: false };
   return { displayText: longName, isSelf: false };
 };
@@ -27,4 +30,23 @@ export const formatMessageTime = (time: number): string => {
 export const getNumMessagesText = (numMessages: number): string => {
   if (numMessages === 1) return "1 message";
   return `${numMessages} messages`;
+};
+
+export const getPacketDisplayText = (
+  { data, type }: ChannelMessagePayload,
+) => {
+  if (type === "text") return data;
+
+  const { name, latitudeI, longitudeI } = data;
+  return `Waypoint "${name}" at ${latitudeI}, ${longitudeI}`;
+};
+
+export const getLastChannelMessageDisplayText = (
+  lastMessage: ChannelMessageWithState | null,
+) => {
+  if (lastMessage?.payload.type) {
+    return getPacketDisplayText(lastMessage.payload);
+  }
+
+  return "No messages received on this channel.";
 };


### PR DESCRIPTION
This PR fixes a bug where the channel messaging view would crash when the backend is managing any waypoint structs. This was due to a type issue where TS didn't know how to infer the type of the incoming messages, and would crash when a message didn't have a `text` field. This PR fixes this issue by adding in an explicit `"type"` field on the serialized struct ([see here](https://serde.rs/enum-representations.html#internally-tagged)).

![Screenshot_20230303_103042](https://user-images.githubusercontent.com/46639306/222760905-71f35730-9504-457f-87ef-626984938fbf.png)

Closes #312

