### PR TITLE
Command to Run Algos

### DIFF
--- a/src-tauri/src/analytics/algo_result_enums/ap.rs
+++ b/src-tauri/src/analytics/algo_result_enums/ap.rs
@@ -1,6 +1,7 @@
+use serde::{Deserialize, Serialize};
 use petgraph::graph::NodeIndex;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum APResult {
     Success(Vec<NodeIndex>),
     Error(String),

--- a/src-tauri/src/analytics/algo_result_enums/diff_cen.rs
+++ b/src-tauri/src/analytics/algo_result_enums/diff_cen.rs
@@ -1,6 +1,7 @@
+use serde::{Deserialize, Serialize};
 use std::collections::HashMap;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum DiffCenResult {
     Success(HashMap<String, HashMap<String, f64>>),
     Error(String),

--- a/src-tauri/src/analytics/algo_result_enums/mincut.rs
+++ b/src-tauri/src/analytics/algo_result_enums/mincut.rs
@@ -1,6 +1,7 @@
+use serde::{Deserialize, Serialize};
 use crate::graph::edge::Edge;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum MinCutResult {
     Success(Vec<Edge>),
     Error(String),

--- a/src-tauri/src/analytics/algo_result_enums/most_sim_timeline.rs
+++ b/src-tauri/src/analytics/algo_result_enums/most_sim_timeline.rs
@@ -1,6 +1,7 @@
+use serde::{Deserialize, Serialize};
 use crate::graph::graph_ds::Graph;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum MostSimTResult {
     Success(Graph),
     Error(String),

--- a/src-tauri/src/analytics/algo_result_enums/pred_state.rs
+++ b/src-tauri/src/analytics/algo_result_enums/pred_state.rs
@@ -1,6 +1,7 @@
+use serde::{Deserialize, Serialize};
 use crate::graph::graph_ds::Graph;
 
-#[derive(Debug)]
+#[derive(Debug, Serialize, Deserialize)]
 pub enum PredStateResult {
     Success(Graph),
     Error(String),

--- a/src-tauri/src/analytics/algo_store.rs
+++ b/src-tauri/src/analytics/algo_store.rs
@@ -16,6 +16,8 @@ use crate::graph::graph_ds::Graph;
 /// * `diff_cent` - [`crate::state_err_enums::diff_cen::DiffCenResult`] that stores Success/Error/Empty of diffusion centrality algorithm.
 /// * `most_sim_t` - [`crate::state_err_enums::most_sim_timeline::MostSimTResult`] that stores Success/Error/Empty of most similar timeline algorithm.
 /// * `pred_state` - [`crate::state_err_enums::pred_state::PredStateResult`] that stores Success/Error/Empty of state prediction algorithm.
+
+#[derive(Clone)]
 pub struct AlgoStore {
     pub aps: APResult,
     pub mincut: MinCutResult,

--- a/src-tauri/src/analytics/algo_store.rs
+++ b/src-tauri/src/analytics/algo_store.rs
@@ -6,6 +6,7 @@ use super::algo_result_enums::mincut::MinCutResult;
 use super::algo_result_enums::most_sim_timeline::MostSimTResult;
 use super::algo_result_enums::pred_state::PredStateResult;
 use crate::graph::graph_ds::Graph;
+use serde::{Deserialize, Serialize};
 
 /// Stores the results of the algorithms.
 ///
@@ -17,7 +18,7 @@ use crate::graph::graph_ds::Graph;
 /// * `most_sim_t` - [`crate::state_err_enums::most_sim_timeline::MostSimTResult`] that stores Success/Error/Empty of most similar timeline algorithm.
 /// * `pred_state` - [`crate::state_err_enums::pred_state::PredStateResult`] that stores Success/Error/Empty of state prediction algorithm.
 
-#[derive(Clone)]
+#[derive(Clone, Serialize, Deserialize)]
 pub struct AlgoStore {
     pub aps: APResult,
     pub mincut: MinCutResult,

--- a/src-tauri/src/analytics/algos_config.rs
+++ b/src-tauri/src/analytics/algos_config.rs
@@ -13,7 +13,7 @@ struct Activation {
 }
 
 pub struct Params {
-    pub params: HashMap<String, Box<dyn Any>>,
+    pub params: HashMap<String, Box<dyn Any + Sync + Send>>,
 }
 
 impl Params {
@@ -23,7 +23,7 @@ impl Params {
         }
     }
 
-    pub fn add_param(&mut self, key: String, value: Box<dyn Any>) {
+    pub fn add_param(&mut self, key: String, value: Box<dyn Any + Sync + Send>) {
         self.params.insert(key, value);
     }
 

--- a/src-tauri/src/graph/graph_ds.rs
+++ b/src-tauri/src/graph/graph_ds.rs
@@ -737,53 +737,53 @@ mod tests {
     #[test]
     fn initialize_graph() {
         // Create a graph
-        let mut G = Graph::new();
+        let mut g = super::Graph::new();
 
         // Create a few nodes and edges and add to graph
         let u: String = "u".to_string();
         let v: String = "v".to_string();
         let w: String = "w".to_string();
 
-        let _u_idx = G.add_node(u.clone());
-        let _v_idx = G.add_node(v.clone());
-        let _w_idx = G.add_node(w.clone());
+        let _u_idx = g.add_node(u.clone());
+        let _v_idx = g.add_node(v.clone());
+        let _w_idx = g.add_node(w.clone());
 
-        assert_eq!(G.get_order(), 3);
+        assert_eq!(g.get_order(), 3);
 
-        G.add_edge(u.clone(), v.clone(), 1 as f64);
-        G.add_edge(u.clone(), w.clone(), 1 as f64);
-        G.add_edge(v.clone(), w.clone(), 35 as f64);
+        g.add_edge(u.clone(), v.clone(), 1 as f64);
+        g.add_edge(u.clone(), w.clone(), 1 as f64);
+        g.add_edge(v.clone(), w.clone(), 35 as f64);
 
-        assert_eq!(G.get_size(), 3);
+        assert_eq!(g.get_size(), 3);
 
-        G.update_edge(u.clone(), v.clone(), 11 as f64, None, Some(false));
-        G.remove_edge(u.clone(), w.clone(), None, Some(true));
+        g.update_edge(u.clone(), v.clone(), 11 as f64, None, Some(false));
+        g.remove_edge(u.clone(), w.clone(), None, Some(true));
 
-        assert_eq!(G.get_size(), 2);
+        assert_eq!(g.get_size(), 2);
     }
 
     #[test]
     fn test_parallel_edges() {
-        let mut G = Graph::new();
+        let mut g = super::Graph::new();
 
         let u: String = "u".to_string();
         let v: String = "v".to_string();
 
-        let _u_idx = G.add_node(u.clone());
-        let _v_idx = G.add_node(v.clone());
+        let _u_idx = g.add_node(u.clone());
+        let _v_idx = g.add_node(v.clone());
 
-        G.add_edge(u.clone(), v.clone(), 1 as f64);
-        G.add_edge(u.clone(), v.clone(), 2 as f64);
+        g.add_edge(u.clone(), v.clone(), 1 as f64);
+        g.add_edge(u.clone(), v.clone(), 2 as f64);
 
-        assert_eq!(G.get_size(), 2);
+        assert_eq!(g.get_size(), 2);
 
         // update edge
-        G.update_edge(u.clone(), v.clone(), 11 as f64, Some(0), None);
+        g.update_edge(u.clone(), v.clone(), 11 as f64, Some(0), None);
     }
 
     #[test]
     fn test_adj_matrix() {
-        let mut G1 = Graph::new();
+        let mut g1 = super::Graph::new();
 
         // Create a few nodes and edges and add to graph
         let a = "a".to_string();
@@ -793,33 +793,33 @@ mod tests {
 
         let mut a_node = Node::new(a.clone());
         a_node.set_gps(-72.28486, 43.71489, 1.0);
-        let a_idx = G1.add_node_from_struct(a_node);
+        let a_idx = g1.add_node_from_struct(a_node);
 
         let mut b_node = Node::new(b.clone());
         b_node.set_gps(-72.28239, 43.71584, 1.0);
-        let b_idx = G1.add_node_from_struct(b_node);
+        let b_idx = g1.add_node_from_struct(b_node);
 
         let mut c_node = Node::new(c.clone());
         c_node.set_gps(-72.28332, 43.7114, 1.0);
-        let c_idx = G1.add_node_from_struct(c_node);
+        let c_idx = g1.add_node_from_struct(c_node);
 
         let mut d_node = Node::new(d.clone());
         d_node.set_gps(-72.28085, 43.71235, 1.0);
-        let d_idx = G1.add_node_from_struct(d_node);
+        let d_idx = g1.add_node_from_struct(d_node);
 
         let a_b = Edge::new(a_idx, b_idx, 0.51);
-        G1.add_edge_from_struct(a_b);
+        g1.add_edge_from_struct(a_b);
 
         let a_c = Edge::new(a_idx, c_idx, 0.39);
-        G1.add_edge_from_struct(a_c);
+        g1.add_edge_from_struct(a_c);
 
         let b_c = Edge::new(b_idx, c_idx, 0.4);
-        G1.add_edge_from_struct(b_c);
+        g1.add_edge_from_struct(b_c);
 
         let b_d = Edge::new(b_idx, d_idx, 0.6);
-        G1.add_edge_from_struct(b_d);
+        g1.add_edge_from_struct(b_d);
 
-        let (adj_matrix, int_to_node_id, d_adj) = G1.convert_to_adj_matrix();
+        let (adj_matrix, int_to_node_id, d_adj) = g1.convert_to_adj_matrix();
 
         // assert that the adjacency matrix is correct
         assert_eq!(

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -59,19 +59,13 @@ fn main() {
             inner: Arc::new(async_runtime::Mutex::new(None)),
         })
         .manage(ActiveMeshDevice {
-            inner: Arc::new(async_runtime::Mutex::new(Some(
-                mesh::device::MeshDevice::new(),
-            ))),
+            inner: Arc::new(async_runtime::Mutex::new(None)),
         })
         .manage(ActiveMeshGraph {
-            inner: Arc::new(async_runtime::Mutex::new(Some(
-                mesh::device::MeshGraph::new(),
-            ))),
+            inner: Arc::new(async_runtime::Mutex::new(None)),
         })
         .manage(ActiveMeshState {
-            inner: Arc::new(async_runtime::Mutex::new(Some(
-                analytics::state::State::new(HashMap::new(), false),
-            ))),
+            inner: Arc::new(async_runtime::Mutex::new(None)),
         })
         .invoke_handler(tauri::generate_handler![
             get_all_serial_ports,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -384,8 +384,8 @@ async fn run_algorithms(
         .ok_or("State not initialized")
         .map_err(|e| e.to_string())?;
 
-    state.set_graph(&graph);
-    state.set_bitfield(&bitfield);
+    state.add_graph(&graph);
+    state.set_algos(&bitfield);
     state.run_algos();
     state.get_algo_results()
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -375,7 +375,7 @@ async fn run_algorithms(
 ) -> Result<AlgoStore, String> {
     let mut guard = mesh_graph.inner.lock().await;
     let mut state_guard = algo_state.inner.lock().await;
-    let graph = guard
+    let graph_struct = guard
         .as_mut()
         .ok_or("Graph not initialized")
         .map_err(|e| e.to_string())?;
@@ -384,8 +384,8 @@ async fn run_algorithms(
         .ok_or("State not initialized")
         .map_err(|e| e.to_string())?;
 
-    state.add_graph(&graph);
-    state.set_algos(&bitfield);
+    state.add_graph(&graph_struct.graph);
+    state.set_algos(bitfield);
     state.run_algos();
-    state.get_algo_results()
+    Ok(state.get_algo_results().clone())
 }

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -8,7 +8,7 @@ use analytics::algo_store::AlgoStore;
 use app::protobufs;
 use mesh::serial_connection::{MeshConnection, SerialConnection};
 use serde::{Deserialize, Serialize};
-use std::sync::Arc;
+use std::{sync::Arc, collections::HashMap};
 use tauri::{async_runtime, Manager};
 
 struct ActiveSerialConnection {
@@ -70,7 +70,7 @@ fn main() {
         })
         .manage(ActiveMeshState {
             inner: Arc::new(async_runtime::Mutex::new(Some(
-                analytics::state::State::new(),
+                analytics::state::State::new(HashMap::new(), false),
             ))),
         })
         .invoke_handler(tauri::generate_handler![
@@ -105,7 +105,7 @@ async fn connect_to_serial_port(
     let mut connection = SerialConnection::new();
     let new_device = mesh::device::MeshDevice::new();
     let new_graph = mesh::device::MeshGraph::new();
-    let state = analytics::state::State::new();
+    let state = analytics::state::State::new(HashMap::new(), false);
 
     connection.connect(app_handle.clone(), port_name, 115_200)?;
     connection.configure(new_device.config_id)?;

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -103,12 +103,6 @@ async fn initialize_graph_state(
         *new_state_guard = Some(state);
     }
 
-    // let mut graph_guard = mesh_graph_arc.lock().await;
-    // let mut state_guard = algo_state_arc.lock().await;
-
-    // let graph = graph_guard.as_mut().ok_or("Graph not initialized")?;
-    // let state = state_guard.as_mut().ok_or("State not initialized")?;
-
     Ok(())
 }
 

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -81,7 +81,8 @@ fn main() {
             update_device_config,
             update_device_user,
             send_waypoint,
-            get_node_edges
+            get_node_edges,
+            run_algorithms
         ])
         .run(tauri::generate_context!())
         .expect("error while running tauri application");

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -378,12 +378,10 @@ async fn run_algorithms(
     let mut state_guard = algo_state.inner.lock().await;
     let graph_struct = guard
         .as_mut()
-        .ok_or("Graph not initialized")
-        .map_err(|e| e.to_string())?;
+        .ok_or("Graph not initialized")?;
     let state = state_guard
         .as_mut()
-        .ok_or("State not initialized")
-        .map_err(|e| e.to_string())?;
+        .ok_or("State not initialized")?;
 
     state.add_graph(&graph_struct.graph);
     state.set_algos(bitfield);

--- a/src/features/device/deviceSagas.ts
+++ b/src/features/device/deviceSagas.ts
@@ -68,6 +68,7 @@ function* connectToDeviceWorker(
     yield put(requestSliceActions.setRequestPending({ name: action.type }));
 
     yield call(disconnectFromDeviceWorker);
+    yield call(invoke, "initialize_graph_state", { portName: action.payload });
     yield call(invoke, "connect_to_serial_port", { portName: action.payload });
     yield put(deviceSliceActions.setActiveSerialPort(action.payload));
 


### PR DESCRIPTION
## Goal
Add ability to run algos from the frontend

## Implementation
- Added a state variable with a mutex
- Added a new function for the initialization of the Graph and State (which also calls clone on the arc - [docs](https://doc.rust-lang.org/std/sync/struct.Arc.html))
- Added serialization to the AlgoResults structs and enum
- fixed graph unit tests 

## Testing
- Client builds successfully 
- command can be invoked from frontend with `__TAURI_INVOKE__("run_algorithms", {bitfield:0b11011}).then(console.log).catch(console.error)`
- No testing with real graph for coherent results yet