### PR TITLE
Working node edges

### DIFF
--- a/.gitmodules
+++ b/.gitmodules
@@ -1,4 +1,4 @@
 [submodule "src-tauri/protobufs"]
 	path = src-tauri/protobufs
 	url = https://github.com/uhuruhashimoto/protobufs.git
-	branch = development
+	branch = neighborinfo_module

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -334,6 +334,11 @@ async fn get_node_edges(
         .graph
         .get_edges()
         .iter()
+        .filter(|e| {
+            let u = graph.graph.get_node(e.u);
+            let v = graph.graph.get_node(e.v);
+            u.longitude != 0.0 && u.latitude != 0.0 && v.latitude != 0.0 && v.longitude != 0.0
+        })
         .map(|e| {
             let u = graph.graph.get_node(e.u);
             let v = graph.graph.get_node(e.v);

--- a/src-tauri/src/mesh/device/connection.rs
+++ b/src-tauri/src/mesh/device/connection.rs
@@ -158,7 +158,6 @@ impl MeshDevice {
             id: generate_rand_id(),
             want_ack,
             channel,
-            last_sent_by_id: own_node_id,
         };
 
         if echo_response {


### PR DESCRIPTION
## Goal
Update backend to modularized firmware and don't add edges for nodes without a position in the graph (which are at 0).

## Implementation
- filtered nodes in command (not in graph construction)

## Testing
![Screenshot_20230306_180700](https://user-images.githubusercontent.com/79157060/223282680-279839b4-a1c6-4ea7-9ce6-2aef7a6d17a2.png)

...for the first time, you can't run our client at (0.0000 0.0000)! Good luck getting there :)
