### PR TITLE
Add CLI option to programatically connect to devices on startup

### DIFF
--- a/src-tauri/Cargo.lock
+++ b/src-tauri/Cargo.lock
@@ -154,6 +154,17 @@ dependencies = [
 ]
 
 [[package]]
+name = "atty"
+version = "0.2.14"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "d9b39be18770d11421cdb1b9947a45dd3f37e93092cbf377614828a319d5fee8"
+dependencies = [
+ "hermit-abi",
+ "libc",
+ "winapi",
+]
+
+[[package]]
 name = "autocfg"
 version = "1.1.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -320,6 +331,30 @@ name = "cfg-if"
 version = "1.0.0"
 source = "registry+https://github.com/rust-lang/crates.io-index"
 checksum = "baf1de4339761588bc0619e3cbc0120ee582ebb74b53b4efbf79117bd2da40fd"
+
+[[package]]
+name = "clap"
+version = "3.2.23"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "71655c45cb9845d3270c9d6df84ebe72b4dad3c2ba3f7023ad47c144e4e473a5"
+dependencies = [
+ "atty",
+ "bitflags",
+ "clap_lex",
+ "indexmap",
+ "strsim",
+ "termcolor",
+ "textwrap",
+]
+
+[[package]]
+name = "clap_lex"
+version = "0.2.4"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "2850f2f5a82cbf437dd5af4d49848fbdfc27c157c3d010345776f952765261c5"
+dependencies = [
+ "os_str_bytes",
+]
 
 [[package]]
 name = "cocoa"
@@ -1969,6 +2004,12 @@ dependencies = [
 ]
 
 [[package]]
+name = "os_str_bytes"
+version = "6.5.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "ceedf44fb00f2d1984b0bc98102627ce622e083e49a5bacdb3e514fa4238e267"
+
+[[package]]
 name = "overload"
 version = "0.1.1"
 source = "registry+https://github.com/rust-lang/crates.io-index"
@@ -3153,6 +3194,7 @@ checksum = "efbf22abd61d95ca9b2becd77f9db4c093892f73e8a07d21d8b0b2bf71a7bcea"
 dependencies = [
  "anyhow",
  "attohttpc",
+ "clap",
  "cocoa",
  "dirs-next",
  "embed_plist",
@@ -3355,6 +3397,21 @@ dependencies = [
  "mac",
  "utf-8",
 ]
+
+[[package]]
+name = "termcolor"
+version = "1.2.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "be55cf8942feac5c765c2c993422806843c9a9a45d4d5c407ad6dd2ea95eb9b6"
+dependencies = [
+ "winapi-util",
+]
+
+[[package]]
+name = "textwrap"
+version = "0.16.0"
+source = "registry+https://github.com/rust-lang/crates.io-index"
+checksum = "222a222a5bfe1bba4a77b45ec488a741b3cb8872e5e499451fd7d0129c9c7c3d"
 
 [[package]]
 name = "thin-slice"

--- a/src-tauri/Cargo.toml
+++ b/src-tauri/Cargo.toml
@@ -25,7 +25,7 @@ defaultdict = "0.13.0"
 reqwest = { version = "0.11", features = ["json"] }
 serde_json = "1.0"
 serde = { version = "1.0", features = ["derive"] }
-tauri = { version = "1.1.1", features = ["clipboard-write-text", "http-all", "notification-all", "shell-open", "windows7-compat"] }
+tauri = { version = "1.1.1", features = ["cli", "clipboard-write-text", "http-all", "notification-all", "shell-open", "windows7-compat"] }
 tokio = { version = "1.21.2", features = ["full"] }
 tracing = "0.1.37"
 tracing-subscriber = "0.3.16"

--- a/src-tauri/src/ipc/commands.rs
+++ b/src-tauri/src/ipc/commands.rs
@@ -13,27 +13,16 @@ use super::CommandError;
 use super::{events, APMincutStringResults};
 
 #[tauri::command]
-pub async fn check_device_connected(
-    mesh_device: tauri::State<'_, state::ActiveMeshDevice>,
-    serial_connection: tauri::State<'_, state::ActiveSerialConnection>,
-) -> Result<bool, CommandError> {
-    let device_guard = mesh_device.inner.lock().await;
-    let serial_guard = serial_connection.inner.lock().await;
-
-    Ok(device_guard.is_some() && serial_guard.is_some())
-}
-
-#[tauri::command]
-pub async fn request_device_state(
-    mesh_device: tauri::State<'_, state::ActiveMeshDevice>,
-) -> Result<mesh::device::MeshDevice, CommandError> {
-    let device_guard = mesh_device.inner.lock().await;
-    let device = device_guard
+pub async fn request_autoconnect_port(
+    autoconnect_state: tauri::State<'_, state::AutoConnectState>,
+) -> Result<String, CommandError> {
+    let autoconnect_port_guard = autoconnect_state.inner.lock().await;
+    let autoconnect_port = autoconnect_port_guard
         .as_ref()
-        .ok_or("Device not initialized")?
+        .ok_or("Autoconnect port state not initialized")?
         .clone();
 
-    Ok(device)
+    Ok(autoconnect_port)
 }
 
 #[tauri::command]

--- a/src-tauri/src/ipc/helpers.rs
+++ b/src-tauri/src/ipc/helpers.rs
@@ -1,5 +1,13 @@
+use std::sync::Arc;
+use tauri::async_runtime;
+
 use crate::graph;
+use crate::ipc::events;
 use crate::mesh;
+use crate::mesh::device::{MeshDevice, MeshGraph};
+use crate::mesh::serial_connection::MeshConnection;
+
+use super::CommandError;
 
 pub fn generate_graph_edges_geojson(
     graph: &mut mesh::device::MeshGraph,
@@ -64,4 +72,90 @@ pub fn node_index_to_node_id(
         }
         None
     })
+}
+
+pub fn initialize_serial_connection_handlers(
+    port_name: String,
+    app_handle: tauri::AppHandle,
+    mesh_device_arc: Arc<async_runtime::Mutex<Option<MeshDevice>>>,
+    mesh_graph_arc: Arc<async_runtime::Mutex<Option<MeshGraph>>>,
+) -> Result<
+    (
+        mesh::serial_connection::SerialConnection,
+        mesh::device::MeshDevice,
+    ),
+    CommandError,
+> {
+    let mut connection = mesh::serial_connection::SerialConnection::new();
+    let new_device = mesh::device::MeshDevice::new();
+
+    connection.connect(app_handle.clone(), port_name, 115_200)?;
+    connection.configure(new_device.config_id)?;
+
+    let mut decoded_listener = connection
+        .on_decoded_packet
+        .as_ref()
+        .ok_or("Decoded packet listener not open")?
+        .resubscribe();
+
+    let handle = app_handle;
+
+    tauri::async_runtime::spawn(async move {
+        while let Ok(message) = decoded_listener.recv().await {
+            let variant = match message.payload_variant {
+                Some(v) => v,
+                None => continue,
+            };
+
+            let mut device_guard = mesh_device_arc.lock().await;
+            let device = match device_guard.as_mut().ok_or("Device not initialized") {
+                Ok(d) => d,
+                Err(e) => {
+                    eprintln!("{:?}", e);
+                    continue;
+                }
+            };
+            let mut graph_guard = mesh_graph_arc.lock().await;
+            let graph = match graph_guard.as_mut().ok_or("Graph not initialized") {
+                Ok(g) => g,
+                Err(e) => {
+                    eprintln!("{:?}", e);
+                    continue;
+                }
+            };
+
+            let (device_updated, graph_updated) =
+                match device.handle_packet_from_radio(variant, Some(handle.clone()), Some(graph)) {
+                    Ok(d) => d,
+                    Err(e) => {
+                        eprintln!("Error transmitting packet: {}", e);
+                        continue;
+                    }
+                };
+
+            println!("Updates: {:?}, {:?}", device_updated, graph_updated);
+
+            if device_updated {
+                match events::dispatch_updated_device(handle.clone(), device.clone()) {
+                    Ok(_) => (),
+                    Err(e) => {
+                        eprintln!("Error emitting event to client: {:?}", e.to_string());
+                        continue;
+                    }
+                };
+            }
+
+            if graph_updated {
+                match events::dispatch_updated_edges(handle.clone(), graph) {
+                    Ok(_) => (),
+                    Err(e) => {
+                        eprintln!("Error emitting event to client: {:?}", e.to_string());
+                        continue;
+                    }
+                };
+            }
+        }
+    });
+
+    Ok((connection, new_device))
 }

--- a/src-tauri/src/ipc/helpers.rs
+++ b/src-tauri/src/ipc/helpers.rs
@@ -157,8 +157,6 @@ pub async fn initialize_serial_connection_handlers(
                     }
                 };
 
-            println!("Updates: {:?}, {:?}", device_updated, graph_updated);
-
             if device_updated {
                 match events::dispatch_updated_device(handle.clone(), device.clone()) {
                     Ok(_) => (),

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -7,22 +7,85 @@ mod mesh;
 mod state;
 
 use std::sync::Arc;
-use tauri::async_runtime;
+use tauri::{async_runtime, Manager};
 
 fn main() {
+    let initial_connection_state = state::ActiveSerialConnection {
+        inner: Arc::new(async_runtime::Mutex::new(None)),
+    };
+
+    let initial_device_state = state::ActiveMeshDevice {
+        inner: Arc::new(async_runtime::Mutex::new(None)),
+    };
+
+    let initial_graph_state = state::NetworkGraph {
+        inner: Arc::new(async_runtime::Mutex::new(None)),
+    };
+
+    let initial_analytics_state = state::AnalyticsState {
+        inner: Arc::new(async_runtime::Mutex::new(None)),
+    };
+
     tracing_subscriber::fmt::init();
     tauri::Builder::default()
-        .manage(state::ActiveSerialConnection {
-            inner: Arc::new(async_runtime::Mutex::new(None)),
-        })
-        .manage(state::ActiveMeshDevice {
-            inner: Arc::new(async_runtime::Mutex::new(None)),
-        })
-        .manage(state::NetworkGraph {
-            inner: Arc::new(async_runtime::Mutex::new(None)),
-        })
-        .manage(state::AnalyticsState {
-            inner: Arc::new(async_runtime::Mutex::new(None)),
+        .setup(|app| {
+            match app.get_cli_matches() {
+                Ok(matches) => {
+                    let args = matches.args;
+                    println!("Args: {:?}", args);
+
+                    app.app_handle().manage(initial_analytics_state);
+                    app.app_handle().manage(initial_graph_state);
+                    app.app_handle().manage(initial_connection_state);
+                    app.app_handle().manage(initial_device_state);
+
+                    if let Some(port_arg) = args.get("port") {
+                        if let serde_json::Value::String(port_name) = port_arg.value.clone() {
+                            println!("Connecting to port: {:?}", port_name);
+
+                            let handle = app.app_handle();
+
+                            let connection_state = handle.state::<state::ActiveSerialConnection>();
+                            let device_state = handle.state::<state::ActiveMeshDevice>();
+                            let graph_state = handle.state::<state::NetworkGraph>();
+
+                            let (connection, device) =
+                                ipc::helpers::initialize_serial_connection_handlers(
+                                    port_name,
+                                    app.app_handle(),
+                                    device_state.inner.clone(),
+                                    graph_state.inner.clone(),
+                                )?;
+
+                            let connection_arc = connection_state.inner.clone();
+                            let device_arc = device_state.inner.clone();
+
+                            // Need this to unlock async locks in sync function
+                            tokio::runtime::Builder::new_multi_thread()
+                                .enable_all()
+                                .build()
+                                .unwrap()
+                                .block_on(async move {
+                                    {
+                                        let mut connection_guard = connection_arc.lock().await;
+                                        *connection_guard = Some(connection);
+                                    }
+
+                                    // Only need to lock to set device in tauri state
+                                    {
+                                        let mut device_guard = device_arc.lock().await;
+                                        *device_guard = Some(device);
+                                    }
+                                });
+                        }
+                    }
+                }
+                Err(err) => {
+                    eprintln!("Error parsing CLI arguments: {}", err);
+                }
+            }
+
+            Ok(())
         })
         .invoke_handler(tauri::generate_handler![
             ipc::commands::get_all_serial_ports,

--- a/src-tauri/src/main.rs
+++ b/src-tauri/src/main.rs
@@ -9,6 +9,37 @@ mod state;
 use std::sync::Arc;
 use tauri::{async_runtime, Manager};
 
+fn handle_cli_matches(
+    app: &mut tauri::App,
+    inital_autoconnect_state: &mut state::AutoConnectState,
+) -> Result<(), String> {
+    match app.get_cli_matches() {
+        Ok(matches) => {
+            let args = matches.args;
+
+            // Check if user has specified a port name to automatically connect to
+            // If so, store it for future connection attempts
+            if let Some(port_arg) = args.get("port") {
+                if port_arg.occurrences == 0 {
+                    return Ok(());
+                }
+
+                if let serde_json::Value::String(port_name) = port_arg.value.clone() {
+                    *inital_autoconnect_state = state::AutoConnectState {
+                        inner: Arc::new(async_runtime::Mutex::new(Some(port_name))),
+                    };
+                }
+            }
+
+            Ok(())
+        }
+        Err(err) => {
+            eprintln!("Error parsing CLI arguments: {}", err);
+            Err(err.to_string())
+        }
+    }
+}
+
 fn main() {
     let initial_connection_state = state::ActiveSerialConnection {
         inner: Arc::new(async_runtime::Mutex::new(None)),
@@ -26,69 +57,31 @@ fn main() {
         inner: Arc::new(async_runtime::Mutex::new(None)),
     };
 
+    let mut inital_autoconnect_state = state::AutoConnectState {
+        inner: Arc::new(async_runtime::Mutex::new(None)),
+    };
+
     tracing_subscriber::fmt::init();
     tauri::Builder::default()
         .setup(|app| {
-            match app.get_cli_matches() {
-                Ok(matches) => {
-                    let args = matches.args;
-                    println!("Args: {:?}", args);
-
-                    app.app_handle().manage(initial_analytics_state);
-                    app.app_handle().manage(initial_graph_state);
-                    app.app_handle().manage(initial_connection_state);
-                    app.app_handle().manage(initial_device_state);
-
-                    if let Some(port_arg) = args.get("port") {
-                        if port_arg.occurrences == 0 {
-                            return Ok(());
-                        }
-
-                        if let serde_json::Value::String(port_name) = port_arg.value.clone() {
-                            println!("Connecting to port: {:?}", port_name);
-
-                            let handle = app.app_handle();
-
-                            let analytics_state = handle.state::<state::AnalyticsState>();
-                            let connection_state = handle.state::<state::ActiveSerialConnection>();
-                            let device_state = handle.state::<state::ActiveMeshDevice>();
-                            let graph_state = handle.state::<state::NetworkGraph>();
-
-                            // Need this to unlock async locks in sync function
-                            tokio::runtime::Builder::new_current_thread()
-                                .enable_all()
-                                .build()
-                                .unwrap()
-                                .block_on(async move {
-                                    let _result_1 = ipc::helpers::initialize_graph_state(
-                                        graph_state.clone(),
-                                        analytics_state,
-                                    )
-                                    .await;
-
-                                    let _result_2 =
-                                        ipc::helpers::initialize_serial_connection_handlers(
-                                            port_name,
-                                            app.app_handle(),
-                                            device_state,
-                                            connection_state,
-                                            graph_state,
-                                        )
-                                        .await;
-                                });
-                        }
-                    }
-                }
-                Err(err) => {
-                    eprintln!("Error parsing CLI arguments: {}", err);
-                }
+            match handle_cli_matches(app, &mut inital_autoconnect_state) {
+                Ok(_) => {}
+                Err(err) => panic!("Failed to parse CLI args:\n{}", err),
             }
+
+            // Manage application state
+            app.app_handle().manage(initial_analytics_state);
+            app.app_handle().manage(initial_graph_state);
+            app.app_handle().manage(initial_connection_state);
+            app.app_handle().manage(initial_device_state);
+
+            // Autoconnect port state needs to be set after being mutated by CLI parser
+            app.app_handle().manage(inital_autoconnect_state);
 
             Ok(())
         })
         .invoke_handler(tauri::generate_handler![
-            ipc::commands::check_device_connected,
-            ipc::commands::request_device_state,
+            ipc::commands::request_autoconnect_port,
             ipc::commands::get_all_serial_ports,
             ipc::commands::connect_to_serial_port,
             ipc::commands::disconnect_from_serial_port,

--- a/src-tauri/src/state.rs
+++ b/src-tauri/src/state.rs
@@ -2,18 +2,26 @@ use crate::{analytics, mesh};
 use std::sync::Arc;
 use tauri::async_runtime;
 
+#[derive(Debug)]
 pub struct ActiveSerialConnection {
     pub inner: Arc<async_runtime::Mutex<Option<mesh::serial_connection::SerialConnection>>>,
 }
 
+#[derive(Debug)]
 pub struct ActiveMeshDevice {
     pub inner: Arc<async_runtime::Mutex<Option<mesh::device::MeshDevice>>>,
 }
 
+#[derive(Debug)]
 pub struct NetworkGraph {
     pub inner: Arc<async_runtime::Mutex<Option<mesh::device::MeshGraph>>>,
 }
 
 pub struct AnalyticsState {
     pub inner: Arc<async_runtime::Mutex<Option<analytics::state::AnalyticsState>>>,
+}
+
+#[derive(Debug)]
+pub struct AutoConnectState {
+    pub inner: Arc<async_runtime::Mutex<Option<String>>>,
 }

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -69,10 +69,8 @@
       }
     },
     "cli": {
-      "description": "",
-      "longDescription": "",
-      "beforeHelp": "",
-      "afterHelp": "",
+      "description": "A command line interface for launching the (unofficial) Meshtastic Emergency Response Client.",
+      "longDescription": "A CLI that allows for programatic connection to Meshtastic devices while launching the desktop client.",
       "args": [
         {
           "name": "port",

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -68,6 +68,20 @@
         "timestampUrl": ""
       }
     },
+    "cli": {
+      "description": "",
+      "longDescription": "",
+      "beforeHelp": "",
+      "afterHelp": "",
+      "args": [
+        {
+          "name": "port",
+          "short": "P",
+          "takesValue": true,
+          "multiple": false
+        }
+      ]
+    },
     "security": {
       "csp": null
     },

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,6 +1,5 @@
-import React, { useEffect, useState } from "react";
+import React, { useState } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
-import { useDispatch, useSelector } from "react-redux";
 
 import SplashScreen from "@components/SplashScreen/SplashScreen";
 import Sidebar from "@components/Sidebar/Sidebar";
@@ -16,8 +15,6 @@ import RadioConfigPage from "@components/pages/config/RadioConfigPage";
 import PluginConfigPage from "@components/pages/config/PluginConfigPage";
 import ChannelConfigPage from "@components/pages/config/ChannelConfigPage";
 
-import { requestDeviceConnectionStatus } from "@features/device/deviceActions";
-import { selectDeviceConnected } from "@features/device/deviceSelectors";
 import { AppRoutes } from "@utils/routing";
 
 const AppWrapper = () => (
@@ -28,26 +25,11 @@ const AppWrapper = () => (
 );
 
 const App = () => {
-  const dispatch = useDispatch();
-  const isDeviceConnected = useSelector(selectDeviceConnected());
-
   // Bool to allow/disallow the splash screen at startup
   const splashEnabled = true;
 
-  const [isSplashAnimationStarted, setSplashAnimationStarted] = useState(false);
   const [isSplashMounted, setSplashMounted] = useState(splashEnabled);
   const [isOnboardMounted, setOnboardMounted] = useState(true);
-
-  useEffect(() => {
-    if (!isSplashAnimationStarted) {
-      setOnboardMounted(!isDeviceConnected);
-    }
-  }, [isDeviceConnected]);
-
-  const handleSplashAnimationStart = () => {
-    setSplashAnimationStarted(true);
-    dispatch(requestDeviceConnectionStatus());
-  };
 
   const handleSplashUnmount = () => {
     setSplashMounted(false);
@@ -55,12 +37,7 @@ const App = () => {
 
   return (
     <div className="flex flex-row relative">
-      {isSplashMounted && (
-        <SplashScreen
-          onAnimationStart={handleSplashAnimationStart}
-          unmountSelf={handleSplashUnmount}
-        />
-      )}
+      {isSplashMounted && <SplashScreen unmountSelf={handleSplashUnmount} />}
 
       {isOnboardMounted && (
         <SerialConnectPage unmountSelf={() => setOnboardMounted(false)} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -34,21 +34,33 @@ const App = () => {
   // Bool to allow/disallow the splash screen at startup
   const splashEnabled = true;
 
+  const [isSplashAnimationStarted, setSplashAnimationStarted] = useState(false);
   const [isSplashMounted, setSplashMounted] = useState(splashEnabled);
   const [isOnboardMounted, setOnboardMounted] = useState(true);
 
   useEffect(() => {
-    setOnboardMounted(!isDeviceConnected);
+    if (!isSplashAnimationStarted) {
+      setOnboardMounted(!isDeviceConnected);
+    }
   }, [isDeviceConnected]);
 
-  const handleSplashUnmount = () => {
+  const handleSplashAnimationStart = () => {
+    setSplashAnimationStarted(true);
     dispatch(requestDeviceConnectionStatus());
+  };
+
+  const handleSplashUnmount = () => {
     setSplashMounted(false);
   };
 
   return (
     <div className="flex flex-row relative">
-      {isSplashMounted && <SplashScreen unmountSelf={handleSplashUnmount} />}
+      {isSplashMounted && (
+        <SplashScreen
+          onAnimationStart={handleSplashAnimationStart}
+          unmountSelf={handleSplashUnmount}
+        />
+      )}
 
       {isOnboardMounted && (
         <SerialConnectPage unmountSelf={() => setOnboardMounted(false)} />

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -35,12 +35,16 @@ const App = () => {
     setSplashMounted(false);
   };
 
+  const handleSerialConnectUnmount = () => {
+    setOnboardMounted(false);
+  };
+
   return (
     <div className="flex flex-row relative">
       {isSplashMounted && <SplashScreen unmountSelf={handleSplashUnmount} />}
 
       {isOnboardMounted && (
-        <SerialConnectPage unmountSelf={() => setOnboardMounted(false)} />
+        <SerialConnectPage unmountSelf={handleSerialConnectUnmount} />
       )}
 
       <Routes>

--- a/src/App.tsx
+++ b/src/App.tsx
@@ -1,5 +1,6 @@
-import React, { useState } from "react";
+import React, { useEffect, useState } from "react";
 import { Routes, Route, Outlet } from "react-router-dom";
+import { useDispatch, useSelector } from "react-redux";
 
 import SplashScreen from "@components/SplashScreen/SplashScreen";
 import Sidebar from "@components/Sidebar/Sidebar";
@@ -15,6 +16,8 @@ import RadioConfigPage from "@components/pages/config/RadioConfigPage";
 import PluginConfigPage from "@components/pages/config/PluginConfigPage";
 import ChannelConfigPage from "@components/pages/config/ChannelConfigPage";
 
+import { requestDeviceConnectionStatus } from "@features/device/deviceActions";
+import { selectDeviceConnected } from "@features/device/deviceSelectors";
 import { AppRoutes } from "@utils/routing";
 
 const AppWrapper = () => (
@@ -25,21 +28,27 @@ const AppWrapper = () => (
 );
 
 const App = () => {
+  const dispatch = useDispatch();
+  const isDeviceConnected = useSelector(selectDeviceConnected());
+
   // Bool to allow/disallow the splash screen at startup
   const splashEnabled = true;
 
   const [isSplashMounted, setSplashMounted] = useState(splashEnabled);
-  const [isOnboardMounted, setOnboardMounted] = useState(splashEnabled);
+  const [isOnboardMounted, setOnboardMounted] = useState(true);
+
+  useEffect(() => {
+    setOnboardMounted(!isDeviceConnected);
+  }, [isDeviceConnected]);
+
+  const handleSplashUnmount = () => {
+    dispatch(requestDeviceConnectionStatus());
+    setSplashMounted(false);
+  };
 
   return (
     <div className="flex flex-row relative">
-      {isSplashMounted && (
-        <SplashScreen
-          unmountSelf={() => {
-            setSplashMounted(false);
-          }}
-        />
-      )}
+      {isSplashMounted && <SplashScreen unmountSelf={handleSplashUnmount} />}
 
       {isOnboardMounted && (
         <SerialConnectPage unmountSelf={() => setOnboardMounted(false)} />

--- a/src/components/SplashScreen/SplashScreen.tsx
+++ b/src/components/SplashScreen/SplashScreen.tsx
@@ -11,14 +11,10 @@ import SplashScreenLogo from "@components/SplashScreen/SplashScreenLogo";
 import "@components/SplashScreen/SplashScreen.css";
 
 export interface ISplashScreenProps {
-  onAnimationStart: () => void;
   unmountSelf: () => void;
 }
 
-const SplashScreen = ({
-  onAnimationStart,
-  unmountSelf,
-}: ISplashScreenProps) => {
+const SplashScreen = ({ unmountSelf }: ISplashScreenProps) => {
   const [isParticlesLoaded, setParticlesLoaded] = useState(false);
   const [isScreenLoaded, setScreenLoaded] = useState(false);
   const [isScreenActive, setScreenActive] = useState(true);
@@ -37,7 +33,6 @@ const SplashScreen = ({
     if (!isParticlesLoaded) return;
 
     const loadingHandle = setTimeout(() => {
-      onAnimationStart();
       setScreenLoaded(true);
     }, 900);
 

--- a/src/components/SplashScreen/SplashScreen.tsx
+++ b/src/components/SplashScreen/SplashScreen.tsx
@@ -11,10 +11,14 @@ import SplashScreenLogo from "@components/SplashScreen/SplashScreenLogo";
 import "@components/SplashScreen/SplashScreen.css";
 
 export interface ISplashScreenProps {
+  onAnimationStart: () => void;
   unmountSelf: () => void;
 }
 
-const SplashScreen = ({ unmountSelf }: ISplashScreenProps) => {
+const SplashScreen = ({
+  onAnimationStart,
+  unmountSelf,
+}: ISplashScreenProps) => {
   const [isParticlesLoaded, setParticlesLoaded] = useState(false);
   const [isScreenLoaded, setScreenLoaded] = useState(false);
   const [isScreenActive, setScreenActive] = useState(true);
@@ -33,6 +37,7 @@ const SplashScreen = ({ unmountSelf }: ISplashScreenProps) => {
     if (!isParticlesLoaded) return;
 
     const loadingHandle = setTimeout(() => {
+      onAnimationStart();
       setScreenLoaded(true);
     }, 900);
 

--- a/src/components/pages/SerialConnectPage.tsx
+++ b/src/components/pages/SerialConnectPage.tsx
@@ -8,10 +8,14 @@ import Meshtastic_Logo from "@app/assets/Mesh_Logo_Black.png";
 import SerialPortOption from "@components/Onboard/SerialPortOption";
 
 import {
+  requestAutoConnectPort,
   requestAvailablePorts,
   requestConnectToDevice,
 } from "@features/device/deviceActions";
-import { selectAvailablePorts } from "@features/device/deviceSelectors";
+import {
+  selectAutoConnectPort,
+  selectAvailablePorts,
+} from "@features/device/deviceSelectors";
 import { selectRequestStateByName } from "@features/requests/requestSelectors";
 import {
   IRequestState,
@@ -27,6 +31,8 @@ export interface IOnboardPageProps {
 const SerialConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
   const dispatch = useDispatch();
   const availableSerialPorts = useSelector(selectAvailablePorts());
+  const autoConnectPort = useSelector(selectAutoConnectPort());
+
   const [selectedPortName, setSelectedPortName] = useState("");
   const [isScreenActive, setScreenActive] = useState(true);
 
@@ -57,8 +63,17 @@ const SerialConnectPage = ({ unmountSelf }: IOnboardPageProps) => {
   };
 
   useEffect(() => {
+    dispatch(requestAutoConnectPort());
     requestPorts();
   }, []);
+
+  // If a port has been marked for automatic connection,
+  // connect to it as if a user selected it manually
+  useEffect(() => {
+    if (autoConnectPort) {
+      handlePortSelected(autoConnectPort);
+    }
+  }, [autoConnectPort]);
 
   // Wait to allow user to recognize serial connection succeeded
   useEffect(() => {

--- a/src/features/device/deviceActions.ts
+++ b/src/features/device/deviceActions.ts
@@ -2,16 +2,20 @@ import { createAction } from "@reduxjs/toolkit";
 import type { User } from "@bindings/protobufs/User";
 import type { Waypoint } from "@bindings/protobufs/Waypoint";
 
+export const requestDeviceConnectionStatus = createAction(
+  "@device/device-connection-status",
+);
+
 export const requestAvailablePorts = createAction(
-  "@device/request-available-ports"
+  "@device/request-available-ports",
 );
 
 export const requestConnectToDevice = createAction<string>(
-  "@device/request-connect"
+  "@device/request-connect",
 );
 
 export const requestDisconnectFromDevice = createAction(
-  "@device/request-disconnect"
+  "@device/request-disconnect",
 );
 
 export const requestSendMessage = createAction<{
@@ -20,7 +24,7 @@ export const requestSendMessage = createAction<{
 }>("@device/request-send-message");
 
 export const requestUpdateUser = createAction<{ user: User }>(
-  "@device/update-device-user"
+  "@device/update-device-user",
 );
 
 export const requestNewWaypoint = createAction<{

--- a/src/features/device/deviceActions.ts
+++ b/src/features/device/deviceActions.ts
@@ -2,10 +2,6 @@ import { createAction } from "@reduxjs/toolkit";
 import type { User } from "@bindings/protobufs/User";
 import type { Waypoint } from "@bindings/protobufs/Waypoint";
 
-export const requestDeviceConnectionStatus = createAction(
-  "@device/device-connection-status",
-);
-
 export const requestAvailablePorts = createAction(
   "@device/request-available-ports",
 );
@@ -31,3 +27,7 @@ export const requestNewWaypoint = createAction<{
   waypoint: Waypoint;
   channel: number;
 }>("@device/send-waypoint");
+
+export const requestAutoConnectPort = createAction(
+  "@device/request-autoconnect-port",
+);

--- a/src/features/device/deviceSelectors.ts
+++ b/src/features/device/deviceSelectors.ts
@@ -5,40 +5,28 @@ import type { User } from "@bindings/protobufs/User";
 import type { MeshChannel } from "@bindings/MeshChannel";
 import type { Waypoint } from "@bindings/protobufs/Waypoint";
 
-export const selectAvailablePorts =
-  () =>
-  (state: RootState): string[] | null =>
-    state.devices.availableSerialPorts;
+export const selectAvailablePorts = () => (state: RootState): string[] | null =>
+  state.devices.availableSerialPorts;
 
-export const selectActiveSerialPort =
-  () =>
-  (state: RootState): string | null =>
-    state.devices.activeSerialPort;
+export const selectActiveSerialPort = () => (state: RootState): string | null =>
+  state.devices.activeSerialPort;
 
-export const selectDevice =
-  () =>
-  (state: RootState): MeshDevice | null =>
-    state.devices.device;
+export const selectDevice = () => (state: RootState): MeshDevice | null =>
+  state.devices.device;
 
 export const selectConnectedDeviceNodeId =
-  () =>
-  (state: RootState): number | null =>
+  () => (state: RootState): number | null =>
     // eslint-disable-next-line @typescript-eslint/no-unsafe-assignment, @typescript-eslint/no-unsafe-member-access, @typescript-eslint/no-unsafe-return
     state.devices.device?.myNodeInfo.myNodeNum ?? null;
 
-export const selectDeviceConnected =
-  () =>
-  (state: RootState): boolean =>
-    !!state.devices.device;
+export const selectDeviceConnected = () => (state: RootState): boolean =>
+  !!state.devices.device;
 
-export const selectAllNodes =
-  () =>
-  (state: RootState): MeshNode[] =>
-    Object.values(state.devices.device?.nodes ?? []);
+export const selectAllNodes = () => (state: RootState): MeshNode[] =>
+  Object.values(state.devices.device?.nodes ?? []);
 
 export const selectNodeById =
-  (id: number) =>
-  (state: RootState): MeshNode | null => {
+  (id: number) => (state: RootState): MeshNode | null => {
     for (const node of selectAllNodes()(state)) {
       if (node.data.num === id) return node;
     }
@@ -49,42 +37,33 @@ export const selectNodeById =
 export const selectActiveNodeId = () => (state: RootState) =>
   state.devices.activeNode;
 
-export const selectActiveNode =
-  () =>
-  (state: RootState): MeshNode | null => {
-    const activeNodeId = selectActiveNodeId()(state);
-    if (!activeNodeId) return null;
-    return selectNodeById(activeNodeId)(state);
-  };
+export const selectActiveNode = () => (state: RootState): MeshNode | null => {
+  const activeNodeId = selectActiveNodeId()(state);
+  if (!activeNodeId) return null;
+  return selectNodeById(activeNodeId)(state);
+};
 
 export const selectAllUsersByNodeIds =
-  () =>
-  (state: RootState): Record<number, User | null> =>
+  () => (state: RootState): Record<number, User | null> =>
     selectAllNodes()(state).reduce((accum, n) => {
       const user = n.data.user;
       return user ? { ...accum, [n.data.num]: user } : accum;
     }, [] as User[]);
 
 export const selectUserByNodeId =
-  (nodeId: number) =>
-  (state: RootState): User | null =>
+  (nodeId: number) => (state: RootState): User | null =>
     selectNodeById(nodeId)(state)?.data.user ?? null;
 
-export const selectDeviceChannels =
-  () =>
-  (state: RootState): MeshChannel[] =>
-    Object.values(selectDevice()(state)?.channels ?? []);
+export const selectDeviceChannels = () => (state: RootState): MeshChannel[] =>
+  Object.values(selectDevice()(state)?.channels ?? []);
 
 // Returns list of all waypoints on connected node
-export const selectAllWaypoints =
-  () =>
-  (state: RootState): Waypoint[] =>
-    Object.values(state.devices.device?.waypoints ?? []);
+export const selectAllWaypoints = () => (state: RootState): Waypoint[] =>
+  Object.values(state.devices.device?.waypoints ?? []);
 
 // Returns single waypoint object given ID
 export const selectWaypointByID =
-  (id: number) =>
-  (state: RootState): Waypoint | null => {
+  (id: number) => (state: RootState): Waypoint | null => {
     for (const waypoint of selectAllWaypoints()(state)) {
       if (waypoint.id === id) return waypoint;
     }
@@ -97,8 +76,7 @@ export const selectActiveWaypointID = () => (state: RootState) =>
 
 // Get actual Waypoint object that's active
 export const selectActiveWaypoint =
-  () =>
-  (state: RootState): Waypoint | null => {
+  () => (state: RootState): Waypoint | null => {
     const activeID = selectActiveWaypointID()(state);
     if (activeID) {
       return selectWaypointByID(activeID)(state);
@@ -116,3 +94,6 @@ export const selectAllowOnMapWaypointCreation = () => (state: RootState) =>
 
 export const selectShowAlgosAccordion = () => (state: RootState) =>
   state.devices.showAlgosAccordion;
+
+export const selectAutoConnectPort = () => (state: RootState) =>
+  state.devices.autoConnectPort;

--- a/src/features/device/deviceSlice.ts
+++ b/src/features/device/deviceSlice.ts
@@ -12,6 +12,7 @@ export interface IDeviceState {
   waypointEdit: boolean; // Controls if the waypoint edit menu, or the normal menu shows up on map
   allowOnMapWaypointCreation: boolean; // If true, we can create new waypoints from the map
   showAlgosAccordion: boolean;
+  autoConnectPort: string | null; // Port to automatically connect to on startup
 }
 
 export const initialDeviceState: IDeviceState = {
@@ -23,6 +24,7 @@ export const initialDeviceState: IDeviceState = {
   waypointEdit: false,
   allowOnMapWaypointCreation: false,
   showAlgosAccordion: true,
+  autoConnectPort: null,
 };
 
 export const deviceSlice = createSlice({
@@ -31,7 +33,7 @@ export const deviceSlice = createSlice({
   reducers: {
     setAvailableSerialPorts: (
       state,
-      action: PayloadAction<string[] | null>
+      action: PayloadAction<string[] | null>,
     ) => {
       state.availableSerialPorts = action.payload;
     },
@@ -46,7 +48,7 @@ export const deviceSlice = createSlice({
 
     setActiveNode: (
       state,
-      action: PayloadAction<MeshNode["data"]["num"] | null>
+      action: PayloadAction<MeshNode["data"]["num"] | null>,
     ) => {
       state.activeNode = action.payload;
       if (action.payload) {
@@ -58,7 +60,7 @@ export const deviceSlice = createSlice({
 
     setActiveWaypoint: (
       state,
-      action: PayloadAction<Waypoint["id"] | null>
+      action: PayloadAction<Waypoint["id"] | null>,
     ) => {
       state.activeWaypoint = action.payload;
       if (action.payload) {
@@ -84,6 +86,10 @@ export const deviceSlice = createSlice({
         state.activeNode = null;
         state.activeWaypoint = null;
       }
+    },
+
+    setAutoConnectPort: (state, action: PayloadAction<string | null>) => {
+      state.autoConnectPort = action.payload;
     },
   },
 });


### PR DESCRIPTION
Per suggestion by @d4rk4, this PR adds in the ability to programmatically connect to Meshtastic serial devices instead of manually selecting them during application launch. The syntax to do so follows the pattern `EXECUTABLE --port PORT_NAME` or `EXECUTABLE -P PORT_NAME`. If a port is specified, the application will store its name in Tauri state.

The UI layer then queries if the application has a port marked for automatic connection (the `request_autoconnect_port` command). If this command returns a valid port name, the UI layer will then connect to this port as if the user selected it manually (see `SerialConnectionPage.tsx`).

If connection fails, the application will display the serial connection UI as usual.

> **Note:** Running the application with CLI arguments requires the application to be built using the `pnpm run rust:build` command, since CLI parsing is not reliable in development with PNPM.

Closes #299 