### PR TITLE
Project Rebrand to "Meshtastic Network Management Client"

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,7 +2,7 @@
 
 <div align="center">
   <h1 align="center">Meshtastic Network Management Client</h1>
-  <p align="center">An unofficial Meshtastic desktop client, allowing simple, offline deployment and administration of a mesh communication network.</p>
+  <p align="center">An unofficial Meshtastic desktop client for analyzing and managing large-scale, low-bandwidth mesh networks</p>
 </div>
 
 <p align="center">
@@ -38,19 +38,62 @@
 
 <!-- > :bangbang: **This application is in early alpha development. For the time being, all images shown in this README are Figma designs and are likely not implemented. We will update this README when this functionality is implemented.** :bangbang: -->
 
-This application is an unofficial desktop client for the [Meshtastic Project](https://meshtastic.org/), with the goal of allowing emergency response workers to deploy and manage an off-grid mesh network. Currently, many emergency response teams utilize UHF/VHF analog radios, and while reliable, cannot reliably transmit vital data over long distances (GPS waypoints, regions of interest, etc). Our goal is to allow response coordinators to purchase [cheap, off-shelf radio hardware](https://meshtastic.org/docs/supported-hardware) and quickly and reliably use that hardware to communicate this vital response information.
-
-This application is built using the [Tauri Framework](https://tauri.app/), a modern, secure successor to the [Electron Framework](https://www.electronjs.org/). This allows us to natively support Linux, macOS, and Windows within the same codebase without the performance or memory overhead of a Chromium browser. Our core application infrastructure is written in Rust, and UI and client functionality is written in React TypeScript and bundled using [Vite](https://vitejs.dev/). This project is in early stages of development, and as such is not yet suitable for production use.
+This application is an unofficial desktop client for the [Meshtastic Project](https://meshtastic.org/), designed to allow users to reliably manage large, decentralized mesh networks. Currently the Meshtastic client ecosystem has strong support for managing single nodes, but minimal support for network-level management and analysis. The goal of this project is to give users confidence in their Meshtastic networks as a reliable communications infrastructure through novel algorithmic analysis and connection-level insights.
 
 <!-- ![image](https://user-images.githubusercontent.com/46639306/197882383-e993add8-0900-4114-9cb6-9e9cb4d331d4.png) -->
 
 ![image](https://user-images.githubusercontent.com/46639306/206596246-0619edd5-7303-4fad-81f0-8c84263016b1.png)
 
-## Features
+This application is built using the [Tauri Framework](https://tauri.app/), a modern, secure successor to the [Electron Framework](https://www.electronjs.org/). This allows us to natively support Linux, macOS, and Windows within the same codebase without the performance or memory overhead of a Chromium browser. Our core application infrastructure is written in Rust due to its performance and safety, and our UI and client functionality is written in React TypeScript using [Vite](https://vitejs.dev/). This project is in early stages of development, and as such is **not yet suitable for production use**.
 
-This project is in early stages of development, but here's a rough roadmap of functionality we're working on.
+## Functionality
 
-- [ ] :earth_americas: Node in-map viewing
+This project is still in early stages of development, but here's a rough roadmap of functionality we're working on. We're placing a high priority on getting our core infrastructure right, since this is the core of any robust and effective UI layer.
+
+- [x] Core dataflow infrastructure
+  - [x] Serial data send/receive
+  - [x] Rust protobuf integration (.proto -> .rs)
+  - [x] Packet encode/decode
+  - [x] Device state management
+- [x] Core UI infrastructure
+  - [x] Tauri command management
+  - [x] Tauri event management
+  - [x] Redux saga dataflow
+- [ ] Network topology collection
+  - [x] RFC for novel packet ([link](https://www.adammcquilkin.com/Adam_McQuilkin_-_Meshtastic_Network_Centralization_Proposal.pdf))
+  - [x] MVP protobuf changes ([link](https://github.com/uhuruhashimoto/protobufs))
+  - [x] MVP firmware changes ([link](https://github.com/uhuruhashimoto/firmware))
+  - [ ] Community protobuf review
+  - [ ] Community firmware review
+- [ ] Algorithmic analysis
+  - [x] Infrastructure
+    - [x] Network packet collation
+    - [x] Network graph construction
+    - [x] Algorithm runners
+  - [ ] UI
+    - [x] MVP algorithm runner pane
+    - [ ] On-map algorithm UI
+    - [ ] Automatic algorithm rerunning
+- [ ] Node management
+  - [x] Node peer table
+  - [ ] Remote node configuration
+- [ ] Waypoint management
+  - [x] Managed waypoint table
+  - [x] In-channel waypoint sending
+  - [ ] On-map waypoint tooltip
+- [ ] Web client parity (UI)
+  - [x] Map node view
+  - [x] Text messaging
+  - [ ] Configuration
+    - [ ] Device configuration
+    - [ ] Module configuration
+    - [ ] Channel configuration
+- [ ] Offline map view
+  - [ ] Offline map storage
+  - [ ] Region-based downloading
+- [ ] Network data export
+
+<!-- - [ ] :earth_americas: Node in-map viewing
   - [x] Mapping service integration
   - [x] Node positioning on map
   - [ ] Offline map usage
@@ -70,7 +113,7 @@ This project is in early stages of development, but here's a rough roadmap of fu
   - [ ] Graph initialization and management
   - [x] Algorithm implementations
   - [ ] Insight utility UI
-- [ ] :floppy_disk: Management summary and export flow
+- [ ] :floppy_disk: Management summary and export flow -->
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -82,31 +82,47 @@ This project is built in Rust and React TypeScript, and managed using the PNPM p
 - [Node.js](https://nodejs.org/en/)
 - [PNPM Package Manager](https://pnpm.io/installation)
 
-Additionally, this project uses [Git submodules](https://git-scm.com/book/en/v2/Git-Tools-Submodules) to include the [meshtastic/protobufs](https://github.com/meshtastic/protobufs) repository. To install this submodule, run `git submodule update --init` after cloning this repository.
+### Installation
+
+For the time being, the only way to run this project is to clone this repository. To do this, follow the steps below:
+
+1. Ensure you have Rust, Node.js, and PNPM installed (see [Prerequisites](#prerequisites))
+2. Clone this repositiory to a local directory. This can be done by running `git clone https://github.com/ajmcquilkin/meshtastic-emergency-response-client.git`
+3. Recursively clone our Git submodules by running `git submodule update --init`
+4. Install all required NPM packages with `pnpm i`
+5. Once you have completed these steps, verify your installation with the `pnpm run rust:dev` command. The application should compile successfully, and you should see the application open successfully. If this process fails for you, please [let us know](https://github.com/ajmcquilkin/meshtastic-emergency-response-client/issues)!
 
 ### Recommended IDE Setup
 
 While this project can be developed within any text editor, we recommend the [Visual Studio Code](https://code.visualstudio.com/) editor. If using VSCode, we strongly recommend that you install the following Visual Studio Code extensions. These extensions both enforce code style and enable language and framework support for our tech stack.
 
-- [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode)
-- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint)
-- [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer)
-- [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode)
-- [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) (optional)
+- [Prettier](https://marketplace.visualstudio.com/items?itemName=esbenp.prettier-vscode) - Formatter for our UI code
+- [ESLint](https://marketplace.visualstudio.com/items?itemName=dbaeumer.vscode-eslint) - Linter for our UI code
+- [rust-analyzer](https://marketplace.visualstudio.com/items?itemName=rust-lang.rust-analyzer) - Rust LSP with code linting, formatting, and quality suggestions
 
-### Commands
+Some optional extensions that aren't required but we find very helpful:
 
-To standardise and simplify our development flow, we utilize PNPM commands (defined in `package.json`). We have created commands which allow for the development of the client only, or development of the client embeddeded in a desktop application window. We support running the application UI in a browser in the event that a contributor wants to make UI changes but is unable to install the required project dependences, although we strongly recommend developing using the `rust:*` commands. You will be unable to connect to a serial device when developing in-browser. Project dependencies can be installed with `pnpm i`.
+- [Tauri](https://marketplace.visualstudio.com/items?itemName=tauri-apps.tauri-vscode) - Adds Tauri [command](https://tauri.app/v1/guides/features/command/) snippets and configuration JSON validation
+- [GitLens](https://marketplace.visualstudio.com/items?itemName=eamodio.gitlens) - A helpful plugin for working with Git histories
 
-> **Reminder:** When using any `rust:*` command, you will need to have the `src-tauri/protobufs` git submodule initialized. To do so, run `git submodule update --init` in the root of the project.
+### Development Commands
+
+To standardize our development flow, we utilize PNPM commands, defined in `package.json`. These commands can be run with the `pnpm run NAME ...ARGS` syntax. Our commands are broken out into two primary categories, `rust:*` commands and `ui:*` commands. The `rust:*` commands run the entire desktop application, where the `ui:*` commands only run the UI layer.
+
+> **Note:** We strongly recommend against using the `ui:dev` and `ui:build` commands manually. These commands are invoked internally by the `rust:dev` and `rust:build` commands, respectively. You will **not** be able to connect to a serial devce when running the `ui:dev` command, as this logic is not handled in the UI layer.
+
+We are currently working to add support for the [Storybook](https://storybook.js.org/) framework, which will allow contributors to develop UI components without running the entire desktop application.
+
+- `pnpm run rust:dev` - Starts the desktop application in development mode, allowing for hot reloading of UI and Rust code
+- `pnpm run rust:build` - Builds the desktop application in production mode for your system architecture. Currently we only use this command for testing our application's CLI argument parser.
+- `pnpm run rust:test` - Runs backend tests on the Rust codebase directory (`/src-tauri`). This command also generates TypeScript client bindings in the `/src-tauri/bindings` directory. Add `-- --show-output` to show Rust `println!` macro calls within test suites.
 
 - `pnpm run ui:dev` - Starts the UI development server, allowing for UI development in a browser environment. Note that any code that interfaces with the Rust backend **will not function** within this browser environment, meaning you will be unable to connect to serial devices in this context
 - `pnpm run ui:build`: - Runs a production build on the UI code into the `dist` directory
-- `pnpm run ui:preview` - Runs the built UI from the `dist` directory. This command must be run after `ui:build`
-- `pnpm run ui:format` - Formats the UI codebase using [Prettier](https://prettier.io/) and [ESLint](https://eslint.org/)
-- `pnpm run ui:test` - Runs UI test suite using [Jest](https://jestjs.io/)
-- `pnpm run rust:dev` - Starts the desktop application in development mode, allowing for hot reloading of UI and Rust code
-- `pnpm run rust:test` - Runs backend tests on the Rust codebase directory (`/src-tauri`). This command also generates TypeScript client bindings in the `/src-tauri/bindings` directory. Add `-- --show-output` to show Rust `println!` macro calls within test suites.
+- `pnpm run ui:lint` - Uses ESLint to check for code style errors. Note that our CI pipeline requires that this command succeeds before any changes can be merged
+- `pnpm run ui:format` - Formats the UI codebase using [Prettier](https://prettier.io/) and [ESLint](https://eslint.org/). We strongly recommend you run this before creating a PR!
+- `pnpm run ui:test` - Runs UI test suite using [Jest](https://jestjs.io/). Currently the project does not have a UI testing suite, but we're very open to contributions!
+- ~~`pnpm run ui:preview` - Runs the built UI from the `dist` directory. This command must be run after `ui:build`~~ (deprecated)
 
 > **Note:** On Linux, your user may not have permission to access a given serial port. If this happens, you will likely need to add your user to the group that controls the serial port you want to access. You can find the group that controls a serial port via the `ls -ld PATH_TO_PORT_HERE` command. You can add your user to this group via the `usermod -a -G GROUP_NAME_HERE $USER` command.
 

--- a/README.md
+++ b/README.md
@@ -1,4 +1,4 @@
-![image](https://user-images.githubusercontent.com/46639306/206589911-37289193-1b7f-441b-81c4-68304b0c55b2.png)
+![image](https://user-images.githubusercontent.com/46639306/229531059-2f07b9c1-982f-4eaa-aae7-b8663e1e94a5.png)
 
 <div align="center">
   <h1 align="center">Meshtastic Network Management Client</h1>

--- a/README.md
+++ b/README.md
@@ -1,7 +1,7 @@
 ![image](https://user-images.githubusercontent.com/46639306/206589911-37289193-1b7f-441b-81c4-68304b0c55b2.png)
 
 <div align="center">
-  <h1 align="center">Meshtastic Emergency Response Client</h1>
+  <h1 align="center">Meshtastic Network Management Client</h1>
   <p align="center">An unofficial Meshtastic desktop client, allowing simple, offline deployment and administration of a mesh communication network.</p>
 </div>
 
@@ -70,7 +70,7 @@ This project is in early stages of development, but here's a rough roadmap of fu
   - [ ] Graph initialization and management
   - [x] Algorithm implementations
   - [ ] Insight utility UI
-- [ ] :floppy_disk: Response summary and export flow
+- [ ] :floppy_disk: Management summary and export flow
 
 ## Development
 

--- a/README.md
+++ b/README.md
@@ -34,38 +34,36 @@
   </a>
 </p>
 
-## Introduction
+## :wave: Introduction
 
 <!-- > :bangbang: **This application is in early alpha development. For the time being, all images shown in this README are Figma designs and are likely not implemented. We will update this README when this functionality is implemented.** :bangbang: -->
 
 This application is an unofficial desktop client for the [Meshtastic Project](https://meshtastic.org/), designed to allow users to reliably manage large, decentralized mesh networks. Currently the Meshtastic client ecosystem has strong support for managing single nodes, but minimal support for network-level management and analysis. The goal of this project is to give users confidence in their Meshtastic networks as a reliable communications infrastructure through novel algorithmic analysis and connection-level insights.
 
-<!-- ![image](https://user-images.githubusercontent.com/46639306/197882383-e993add8-0900-4114-9cb6-9e9cb4d331d4.png) -->
-
-![image](https://user-images.githubusercontent.com/46639306/206596246-0619edd5-7303-4fad-81f0-8c84263016b1.png)
+![image](https://user-images.githubusercontent.com/46639306/229554644-b5c728b6-141d-4034-8a38-9faa14d42a5a.png)
 
 This application is built using the [Tauri Framework](https://tauri.app/), a modern, secure successor to the [Electron Framework](https://www.electronjs.org/). This allows us to natively support Linux, macOS, and Windows within the same codebase without the performance or memory overhead of a Chromium browser. Our core application infrastructure is written in Rust due to its performance and safety, and our UI and client functionality is written in React TypeScript using [Vite](https://vitejs.dev/). This project is in early stages of development, and as such is **not yet suitable for production use**.
 
-## Functionality
+## :rocket: Functionality
 
 This project is still in early stages of development, but here's a rough roadmap of functionality we're working on. We're placing a high priority on getting our core infrastructure right, since this is the core of any robust and effective UI layer.
 
-- [x] Core dataflow infrastructure
+- [x] :link: Core dataflow infrastructure
   - [x] Serial data send/receive
   - [x] Rust protobuf integration (.proto -> .rs)
   - [x] Packet encode/decode
   - [x] Device state management
-- [x] Core UI infrastructure
+- [x] :art: Core UI infrastructure
   - [x] Tauri command management
   - [x] Tauri event management
   - [x] Redux saga dataflow
-- [ ] Network topology collection
+- [ ] :artificial_satellite: Network topology collection
   - [x] RFC for novel packet ([link](https://www.adammcquilkin.com/Adam_McQuilkin_-_Meshtastic_Network_Centralization_Proposal.pdf))
   - [x] MVP protobuf changes ([link](https://github.com/uhuruhashimoto/protobufs))
   - [x] MVP firmware changes ([link](https://github.com/uhuruhashimoto/firmware))
   - [ ] Community protobuf review
   - [ ] Community firmware review
-- [ ] Algorithmic analysis
+- [ ] :nerd_face: Algorithmic analysis
   - [x] Infrastructure
     - [x] Network packet collation
     - [x] Network graph construction
@@ -74,24 +72,24 @@ This project is still in early stages of development, but here's a rough roadmap
     - [x] MVP algorithm runner pane
     - [ ] On-map algorithm UI
     - [ ] Automatic algorithm rerunning
-- [ ] Node management
+- [ ] :radio: Node management
   - [x] Node peer table
   - [ ] Remote node configuration
-- [ ] Waypoint management
+- [ ] :pushpin: Waypoint management
   - [x] Managed waypoint table
   - [x] In-channel waypoint sending
   - [ ] On-map waypoint tooltip
-- [ ] Web client parity (UI)
+- [ ] :globe_with_meridians: Web client parity (UI)
   - [x] Map node view
   - [x] Text messaging
   - [ ] Configuration
     - [ ] Device configuration
     - [ ] Module configuration
     - [ ] Channel configuration
-- [ ] Offline map view
+- [ ] :mount_fuji: Offline map view
   - [ ] Offline map storage
   - [ ] Region-based downloading
-- [ ] Network data export
+- [ ] :page_facing_up: Network data export
 
 <!-- - [ ] :earth_americas: Node in-map viewing
   - [x] Mapping service integration
@@ -115,7 +113,7 @@ This project is still in early stages of development, but here's a rough roadmap
   - [ ] Insight utility UI
 - [ ] :floppy_disk: Management summary and export flow -->
 
-## Development
+## :computer: Development
 
 ### Prerequisites
 
@@ -169,6 +167,6 @@ We are currently working to add support for the [Storybook](https://storybook.js
 
 > **Note:** On Linux, your user may not have permission to access a given serial port. If this happens, you will likely need to add your user to the group that controls the serial port you want to access. You can find the group that controls a serial port via the `ls -ld PATH_TO_PORT_HERE` command. You can add your user to this group via the `usermod -a -G GROUP_NAME_HERE $USER` command.
 
-## Contributing
+## :heart: Contributing
 
 As we are still very early in development, we don't yet have a standardized framework for accepting contributions. This being said, we are very open to suggestions and/or code changes! If you're interested in contributing to this repository, we would ask that you first check our issue board to ensure your work isn't duplicating the work of others. Then, please make an issue on our board so we know what you're interested in working on. If you have any questions about the project, we would love to hear from you!

--- a/README.md
+++ b/README.md
@@ -36,11 +36,9 @@
 
 ## :wave: Introduction
 
-<!-- > :bangbang: **This application is in early alpha development. For the time being, all images shown in this README are Figma designs and are likely not implemented. We will update this README when this functionality is implemented.** :bangbang: -->
-
 This application is an unofficial desktop client for the [Meshtastic Project](https://meshtastic.org/), designed to allow users to reliably manage large, decentralized mesh networks. Currently the Meshtastic client ecosystem has strong support for managing single nodes, but minimal support for network-level management and analysis. The goal of this project is to give users confidence in their Meshtastic networks as a reliable communications infrastructure through novel algorithmic analysis and connection-level insights.
 
-![image](https://user-images.githubusercontent.com/46639306/229554644-b5c728b6-141d-4034-8a38-9faa14d42a5a.png)
+![image](https://user-images.githubusercontent.com/46639306/229562168-bfadd385-58de-4531-b332-bfcaaeb64ab8.png)
 
 This application is built using the [Tauri Framework](https://tauri.app/), a modern, secure successor to the [Electron Framework](https://www.electronjs.org/). This allows us to natively support Linux, macOS, and Windows within the same codebase without the performance or memory overhead of a Chromium browser. Our core application infrastructure is written in Rust due to its performance and safety, and our UI and client functionality is written in React TypeScript using [Vite](https://vitejs.dev/). This project is in early stages of development, and as such is **not yet suitable for production use**.
 

--- a/index.html
+++ b/index.html
@@ -1,18 +1,16 @@
 <!DOCTYPE html>
 <html lang="en">
-  <head>
-    <meta charset="UTF-8" />
-    <link
-      rel="icon"
-      type="image/svg+xml"
-      href="/src/assets/Mesh_Logo_White.svg"
-    />
-    <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>Meshtastic Emergency Response Client</title>
-  </head>
 
-  <body>
-    <div id="root"></div>
-    <script type="module" src="/src/main.tsx"></script>
-  </body>
+<head>
+  <meta charset="UTF-8" />
+  <link rel="icon" type="image/svg+xml" href="/src/assets/Mesh_Logo_White.svg" />
+  <meta name="viewport" content="width=device-width, initial-scale=1.0" />
+  <title>Meshtastic Network Management Client</title>
+</head>
+
+<body>
+  <div id="root"></div>
+  <script type="module" src="/src/main.tsx"></script>
+</body>
+
 </html>

--- a/package.json
+++ b/package.json
@@ -5,15 +5,15 @@
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {
+    "rust:dev": "tauri dev",
+    "rust:build": "tauri build --",
+    "rust:test": "cd src-tauri; cargo test",
     "ui:dev": "vite",
     "ui:build": "tsc && vite build",
-    "ui:preview": "vite preview",
     "ui:lint": "eslint src/*.{ts,tsx}",
     "ui:format": "prettier --write ./src && eslint src/*.{ts,tsx}",
     "ui:test": "jest --passWithNoTests",
-    "rust:dev": "tauri dev",
-    "rust:build": "tauri build --",
-    "rust:test": "cd src-tauri; cargo test"
+    "ui:preview": "vite preview"
   },
   "dependencies": {
     "@heroicons/react": "^2.0.13",

--- a/package.json
+++ b/package.json
@@ -1,7 +1,7 @@
 {
-  "name": "meshtastic-emergency-response-client",
+  "name": "meshtastic-network-management-client",
   "version": "0.0.0",
-  "description": "Meshtastic client for emergency response",
+  "description": "Meshtastic client for network management",
   "license": "GPL-3.0-only",
   "type": "module",
   "scripts": {

--- a/src-tauri/tauri.conf.json
+++ b/src-tauri/tauri.conf.json
@@ -7,7 +7,7 @@
     "distDir": "../dist"
   },
   "package": {
-    "productName": "meshtastic-emergency-response-client",
+    "productName": "meshtastic-network-management-client",
     "version": "0.0.0"
   },
   "tauri": {
@@ -50,7 +50,7 @@
         "icons/icon.icns",
         "icons/icon.ico"
       ],
-      "identifier": "org.meshtastic.emergency",
+      "identifier": "org.meshtastic.network-management",
       "longDescription": "",
       "macOS": {
         "entitlements": null,
@@ -78,7 +78,7 @@
       {
         "maximized": true,
         "resizable": true,
-        "title": "Meshtastic Emergency Response Client"
+        "title": "Meshtastic Network Management Client"
       }
     ]
   }

--- a/src/components/Sidebar/SidebarLogo.tsx
+++ b/src/components/Sidebar/SidebarLogo.tsx
@@ -19,7 +19,7 @@ const SidebarLogo = ({ isSidebarExpanded }: IMeshLogoProps) => {
         style={isSidebarExpanded ? { opacity: 1 } : { opacity: 0 }}
       >
         <p className="text-gray-700 text-sm font-medium">Meshtastic</p>
-        <p className="text-gray-400 text-xs font-normal">Emergency Response</p>
+        <p className="text-gray-400 text-xs font-normal">Network Management</p>
       </div>
     </div>
   );


### PR DESCRIPTION
This PR is a tracking PR for a potential project rename.

As we've discussed internally, our project currently doesn't focus specifically on the emergency response scenario, and if we were to double down on this area of focus, we would run the risk of alienating potential users that would find our network and offline management features useful.

From this, I'm proposing we rename the project from "Meshtastic Emergency Response Client" to "Meshtastic Network Management Client." Within our internal conversations I've heard a lot of talk around making sure that Meshtastic networks are reliable and ensuring users can know enough about their network state to maintain working connections. This would certainly not preclude any work that would assist emergency response workers (much to the contrary I would argue), but we could then expand our reach to any potential application in which it would be advantageous to deploy a Meshtastic network.

If we were to go through with this change, this would entail the following changes:

1. Changing the name of the repository
2. Updating all references of "Emergency Response" to "Network Management" within the project's READMEs
3. Same update within all UI code

I'm not sure where I stand on the logo, since while the plus originally represented the US medical symbol, I could also see a framing where the plus represents the augmented capabilities of the client we're offering. Either way, I would argue that any logo change should be its own separate PR.

Tagging all members of the original project team as reviewers for input.